### PR TITLE
Add first tests

### DIFF
--- a/Dockerfile-devbox
+++ b/Dockerfile-devbox
@@ -3,11 +3,13 @@ LABEL maintainer="sergey.nevmerzhitsky@gmail.com"
 
 WORKDIR /var/app
 
+RUN set -e; \
+    pip install pytest pytest-asyncio grpcio-testing structlog ujson
+
 COPY examples ./examples
 COPY src ./src
 COPY tests ./tests
 COPY pytest.ini README.md setup.py ./
 
 RUN set -e; \
-    pip install pytest pytest-asyncio grpcio-testing; \
     pip install -e .

--- a/Dockerfile-devbox
+++ b/Dockerfile-devbox
@@ -4,7 +4,7 @@ LABEL maintainer="sergey.nevmerzhitsky@gmail.com"
 WORKDIR /var/app
 
 RUN set -e; \
-    pip install pytest pytest-asyncio grpcio-testing structlog ujson
+    pip install pytest pytest-asyncio pytest-mock grpcio-testing structlog ujson
 
 COPY examples ./examples
 COPY src ./src

--- a/Dockerfile-tox
+++ b/Dockerfile-tox
@@ -28,9 +28,9 @@ RUN set -ex; \
     ; \
     curl --location https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash; \
     pyenv update; \
-    pyenv install 3.7.5; \
-    pyenv install 3.8.0; \
-    pyenv global 3.8.0 3.7.5; \
+    pyenv install 3.7.6; \
+    pyenv install 3.8.1; \
+    pyenv global 3.8.1 3.7.6; \
     pyenv rehash; \
     pip install tox==3.14.2; \
     rm -rf /var/lib/apt/lists/*; \

--- a/Dockerfile-tox
+++ b/Dockerfile-tox
@@ -1,39 +1,30 @@
-FROM alpine:3.10
+# Inspired by https://github.com/kiwicom/dockerfiles/tree/master/tox. It's non-extendible
+# unfortunately. Also we don't use Alpine Linux as parent because it's MUSL system,
+# but we required for manylinux1-compatible environment to install protobuf package etc.
+
+FROM python:3.8-slim-buster
 LABEL maintainer="sergey.nevmerzhitsky@gmail.com"
-# Inspired by https://hub.docker.com/r/kiwicom/tox but it non-extendible unfortunately
 
 ENV PATH="$PATH:/root/.pyenv/bin:/root/.pyenv/shims"
 
 RUN set -ex; \
-    apk add --no-cache --virtual=.build-deps \
-        bzip2-dev \
+    apt-get -qy update; \
+    # A partial list from https://github.com/pyenv/pyenv/wiki/Common-build-problems#prerequisites
+    apt-get -qy install \
+        build-essential \
         curl \
         git \
-        linux-headers \
-        ncurses-dev \
-        openssl-dev \
-        patch \
-        sqlite-dev \
-        readline-dev \
-        xz-dev \
-        zlib-dev \
-    ; \
-    apk add --no-cache --virtual=.run-deps \
-        bash \
-        build-base \
-        bzip2 \
-        ca-certificates \
-        libbz2 \
-        libffi \
+        libbz2-dev \
         libffi-dev \
-        ncurses \
-        openssl \
-        postgresql-dev \
-        readline \
-        sqlite \
-        sqlite-libs \
-        xz \
-        zlib \
+        liblzma-dev \
+        libncurses5-dev \
+        libncursesw5-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        python-openssl \
+        xz-utils \
+        zlib1g-dev \
     ; \
     curl --location https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash; \
     pyenv update; \
@@ -42,8 +33,7 @@ RUN set -ex; \
     pyenv global 3.8.0 3.7.5; \
     pyenv rehash; \
     pip install tox==3.14.2; \
-    apk del .build-deps; \
-    rm -rf /var/cache/apk/*; \
+    rm -rf /var/lib/apt/lists/*; \
     rm -rf /tmp/*; \
     find /root/.pyenv/versions -type d '(' -name '__pycache__' -o -name 'test' -o -name 'tests' ')' -exec rm -rfv '{}' +; \
     find /root/.pyenv/versions -type f '(' -name '*.py[co]' -o -name '*.exe' ')' -exec rm -fv '{}' +

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@ set -ex
 rm -rf build/ */*.egg-info
 #rm -rf dist
 
-docker build -t trade-api-python-tox -f Dockerfile-tox .
-docker run --rm -w /docker -v "$(pwd):/docker" trade-api-python-tox tox
+docker-compose build --pull --force-rm tox
+docker-compose run --rm tox
 
 python setup.py sdist bdist_wheel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,13 @@ services:
       - type: bind
         source: ./tests
         target: /var/app/tests
+  tox:
+    build:
+      context: .
+      dockerfile: Dockerfile-tox
+    working_dir: /docker
+    command: tox
+    volumes:
+      - type: bind
+        source: .
+        target: /docker

--- a/examples/example.py
+++ b/examples/example.py
@@ -27,7 +27,7 @@ async def start_trade_system(program_env: AsyncProgramEnv) -> None:
     if not await terminal.auth_user(username, password):
         raise RuntimeError(f'Cannot auth {username}')
 
-    await terminal.get_exchange_entities()
+    await terminal.init_exchange_entities()
     await terminal.wait_exchange_entities_inited()
 
     await terminal.subscribe_to_prices(

--- a/examples/example.py
+++ b/examples/example.py
@@ -27,7 +27,7 @@ async def start_trade_system(program_env: AsyncProgramEnv) -> None:
     if not await terminal.auth_user(username, password):
         raise RuntimeError(f'Cannot auth {username}')
 
-    await terminal.init_exchange_entities()
+    await terminal.get_exchange_entities()
     await terminal.wait_exchange_entities_inited()
 
     await terminal.subscribe_to_prices(

--- a/examples/example.py
+++ b/examples/example.py
@@ -13,8 +13,7 @@ async def start_trade_system(program_env: AsyncProgramEnv) -> None:
     username = 'vasya'
     password = 'pupkin123'
 
-    transport = RealTransportFactory()
-    transport.configure_endpoints(
+    transport = RealTransportFactory(
         exchange_info_dsn='exchange-info.zone:50051',
         depth_scraping_queue_dsn='amqp://depth-scraping.zone/%2F?heartbeat_interval=10',
         depth_scraping_queue_exchange='depth_updates',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='galts-trade-api',
-    version='0.0.1',
+    version='0.0.2',
     license='Mozilla Public License 2.0',
     author='Sergey Nevmerzhitsky',
     author_email='sergey.nevmerzhitsky@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ setuptools.setup(
         'aio-pika~=5.0',
         'grpcio~=1.20',
         'protobuf~=3.11',  # Required by grpc_utils
+        'structlog~=19.2.0',
+        'ujson~=1.35',
     ],
     packages=setuptools.find_packages('src'),
     # https://packaging.python.org/guides/distributing-packages-using-setuptools/#py-modules

--- a/src/galts_trade_api/asset.py
+++ b/src/galts_trade_api/asset.py
@@ -1,13 +1,10 @@
 import datetime
 from typing import Optional
 
-from .transport import TransportFactory
-
 
 class Asset:
     def __init__(
         self,
-        transport_factory: TransportFactory,
         id: int,
         tag: str,
         name: str,
@@ -15,7 +12,6 @@ class Asset:
         create_time: datetime.datetime,
         delete_time: Optional[datetime.datetime]
     ):
-        self._transport_factory = transport_factory
         self._id: int = int(id)
         self._tag: str = str(tag).strip()
         self._name: str = str(name).strip()
@@ -27,14 +23,12 @@ class Asset:
 class Symbol:
     def __init__(
         self,
-        transport_factory: TransportFactory,
         id: int,
         base_asset_id: int,
         quote_asset_id: int,
         create_time: datetime.datetime,
         delete_time: Optional[datetime.datetime]
     ):
-        self._transport_factory = transport_factory
         self._id: int = int(id)
         self._base_asset_id: int = int(base_asset_id)
         self._quote_asset_id: int = int(quote_asset_id)

--- a/src/galts_trade_api/asset.py
+++ b/src/galts_trade_api/asset.py
@@ -19,6 +19,30 @@ class Asset:
         self._create_time: datetime.datetime = create_time
         self._delete_time: Optional[datetime.datetime] = delete_time
 
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def tag(self):
+        return self._tag
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def precision(self):
+        return self._precision
+
+    @property
+    def create_time(self):
+        return self._create_time
+
+    @property
+    def delete_time(self):
+        return self._delete_time
+
 
 class Symbol:
     def __init__(
@@ -34,3 +58,23 @@ class Symbol:
         self._quote_asset_id: int = int(quote_asset_id)
         self._create_time: datetime.datetime = create_time
         self._delete_time: Optional[datetime.datetime] = delete_time
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def base_asset_id(self):
+        return self._base_asset_id
+
+    @property
+    def quote_asset_id(self):
+        return self._quote_asset_id
+
+    @property
+    def create_time(self):
+        return self._create_time
+
+    @property
+    def delete_time(self):
+        return self._delete_time

--- a/src/galts_trade_api/asyncio_helper.py
+++ b/src/galts_trade_api/asyncio_helper.py
@@ -58,7 +58,7 @@ def run_program_forever(
 ) -> None:
     """
     Args:
-        - handle_signals: If None then these signals will be handled: SIGTERM, SIGINT.
+        handle_signals: If None then these signals will be handled: SIGTERM, SIGINT.
     """
     if not loop:
         loop = asyncio.new_event_loop()

--- a/src/galts_trade_api/asyncio_helper.py
+++ b/src/galts_trade_api/asyncio_helper.py
@@ -1,0 +1,118 @@
+import asyncio
+import os
+import signal
+from functools import partial
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence
+
+from .structlogger import get_logger
+
+logger = get_logger('galts_trade_api')
+
+LoopExceptionHandlerCallable = Callable[[asyncio.AbstractEventLoop, Dict[str, Any]], Any]
+
+
+def signal_handler(sig: signal.Signals, loop: asyncio.AbstractEventLoop) -> None:
+    logger.info('Received exit signal', process_id=os.getpid(), signal=sig.name)
+    loop.create_task(shutdown(loop))
+
+
+# Inspired by https://www.roguelynn.com/words/asyncio-exception-handling/
+async def shutdown(loop: asyncio.AbstractEventLoop) -> None:
+    """Cleanup tasks tied to the program's shutdown."""
+    logger.info(f'Shutting down', process_id=os.getpid())
+
+    other_tasks = [t for t in asyncio.all_tasks(loop) if t is not asyncio.current_task(loop)]
+    logger.debug('Cancelling outstanding tasks', process_id=os.getpid(), amount=len(other_tasks))
+    await _cancel_tasks(loop, other_tasks)
+
+    loop.stop()
+
+
+# Do it like asyncio.run()
+async def _cancel_tasks(loop: asyncio.AbstractEventLoop, tasks: List) -> None:
+    if not tasks:
+        return
+
+    for task in tasks:
+        task.cancel()
+
+    await asyncio.gather(*tasks, return_exceptions=True, loop=loop)
+
+    for task in tasks:
+        if task.cancelled():
+            continue
+
+        if task.exception():
+            loop.default_exception_handler({
+                'message': 'Unhandled exception during shutdown',
+                'exception': task.exception(),
+                'task': task,
+            })
+
+
+def run_program_forever(
+    target: Callable[..., Awaitable],
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+    loop_debug: Optional[bool] = None,
+    handle_signals: Optional[Sequence[signal.Signals]] = None
+) -> None:
+    """
+    Args:
+        - handle_signals: If None then these signals will be handled: SIGTERM, SIGINT.
+    """
+    if not loop:
+        loop = asyncio.new_event_loop()
+        new_loop_created = True
+    else:
+        new_loop_created = False
+
+    if loop_debug is not None:
+        loop.set_debug(loop_debug)
+
+    if handle_signals is None:
+        handle_signals = {signal.SIGTERM, signal.SIGINT}
+
+    for sig in handle_signals:
+        loop.add_signal_handler(sig, partial(signal_handler, sig, loop))
+
+    try:
+        env = AsyncProgramEnv()
+        loop.set_exception_handler(env.exception_handler)
+        loop.create_task(target(env))
+        loop.run_forever()
+    finally:
+        if new_loop_created:
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
+
+        logger.info('Successfully shutdown', process_id=os.getpid())
+
+
+class AsyncProgramEnv:
+    """
+    The main purpose of the class is to provide an ability to extend the event loop exception
+    handler. A user can perform additional shutdown tasks in the extension.
+    """
+
+    def __init__(self):
+        self._exception_handler_patch: Optional[LoopExceptionHandlerCallable] = None
+
+    @property
+    def exception_handler_patch(self):
+        return self._exception_handler_patch
+
+    @exception_handler_patch.setter
+    def exception_handler_patch(self, value: Optional[LoopExceptionHandlerCallable] = None):
+        if value is not None and not callable(value):
+            raise TypeError('Value should be a callable or None')
+
+        self._exception_handler_patch = value
+
+    def exception_handler(self, loop: asyncio.AbstractEventLoop, context: Dict[str, Any]) -> None:
+        if self.exception_handler_patch:
+            self.exception_handler_patch(loop, context)
+
+        logger.info('Caught exception', process_id=os.getpid())
+        loop.default_exception_handler(context)
+
+        loop.create_task(shutdown(loop))

--- a/src/galts_trade_api/asyncio_helper.py
+++ b/src/galts_trade_api/asyncio_helper.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import signal
 from functools import partial
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence
+from typing import AbstractSet, Any, Awaitable, Callable, Dict, List, Optional
 
 from .structlogger import get_logger
 
@@ -54,7 +54,7 @@ def run_program_forever(
     target: Callable[..., Awaitable],
     loop: Optional[asyncio.AbstractEventLoop] = None,
     loop_debug: Optional[bool] = None,
-    handle_signals: Optional[Sequence[signal.Signals]] = None
+    handle_signals: Optional[AbstractSet[signal.Signals]] = None
 ) -> None:
     """
     Args:

--- a/src/galts_trade_api/asyncio_helper.py
+++ b/src/galts_trade_api/asyncio_helper.py
@@ -22,7 +22,7 @@ async def shutdown(loop: asyncio.AbstractEventLoop) -> None:
     logger.info(f'Shutting down', process_id=os.getpid())
 
     other_tasks = [t for t in asyncio.all_tasks(loop) if t is not asyncio.current_task(loop)]
-    logger.debug('Cancelling outstanding tasks', process_id=os.getpid(), amount=len(other_tasks))
+    logger.debug('Cancelling outstanding tasks', process_id=os.getpid(), count=len(other_tasks))
     await _cancel_tasks(loop, other_tasks)
 
     loop.stop()

--- a/src/galts_trade_api/exchange.py
+++ b/src/galts_trade_api/exchange.py
@@ -3,13 +3,10 @@ from __future__ import annotations
 import datetime
 from typing import Dict, Optional
 
-from .transport import TransportFactory
-
 
 class Exchange:
     def __init__(
         self,
-        transport_factory: TransportFactory,
         id: int,
         tag: str,
         name: str,
@@ -17,7 +14,6 @@ class Exchange:
         delete_time: Optional[datetime.datetime],
         disable_time: Optional[datetime.datetime]
     ):
-        self._transport_factory = transport_factory
         self._id: int = int(id)
         self._tag: str = str(tag).strip()
         self._name: str = str(name).strip()
@@ -26,14 +22,6 @@ class Exchange:
         self._disable_time: Optional[datetime.datetime] = disable_time
 
         self._markets: Dict[str, Market] = {}
-
-    @property
-    def transport_factory(self):
-        return self._transport_factory
-
-    @transport_factory.setter
-    def transport_factory(self, value):
-        self._transport_factory = value
 
     @property
     def tag(self):
@@ -54,7 +42,6 @@ class Exchange:
 class Market:
     def __init__(
         self,
-        transport_factory: TransportFactory,
         id: int,
         custom_tag: str,
         exchange_id: int,
@@ -63,7 +50,6 @@ class Market:
         create_time: datetime.datetime,
         delete_time: Optional[datetime.datetime]
     ):
-        self._transport_factory = transport_factory
         self._id: int = int(id)
         self._custom_tag: str = str(custom_tag).strip()
         self._exchange_id: int = int(exchange_id)
@@ -71,14 +57,6 @@ class Market:
         self._trade_endpoint: str = str(trade_endpoint).strip()
         self._create_time: datetime.datetime = create_time
         self._delete_time: Optional[datetime.datetime] = delete_time
-
-    @property
-    def transport_factory(self):
-        return self._transport_factory
-
-    @transport_factory.setter
-    def transport_factory(self, value):
-        self._transport_factory = value
 
     @property
     def custom_tag(self):

--- a/src/galts_trade_api/exchange.py
+++ b/src/galts_trade_api/exchange.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import datetime
-from typing import Awaitable, Callable, Dict, List, Optional
+from typing import Dict, Optional
 
-from .transport import DepthConsumeKey, TransportFactory
-
-OnPriceCallable = Callable[[str, str, str, datetime.datetime, List, List], Awaitable]
+from .transport import TransportFactory
 
 
 class Exchange:
@@ -41,7 +39,7 @@ class Exchange:
     def tag(self):
         return self._tag
 
-    def add_market(self, market: Market):
+    def add_market(self, market: Market) -> None:
         if market.custom_tag in self._markets:
             raise ValueError(
                 f'Market with tag "{market.custom_tag}" already exists in exchange {self.tag}'
@@ -85,13 +83,3 @@ class Market:
     @property
     def custom_tag(self):
         return self._custom_tag
-
-    async def subscribe_to_prices(
-        self,
-        callback: OnPriceCallable,
-        consume_keys: Optional[List[DepthConsumeKey]] = None
-    ) -> None:
-        await self.transport_factory.get_depth_scraping_consumer(
-            lambda event: callback(*event),
-            consume_keys
-        )

--- a/src/galts_trade_api/exchange.py
+++ b/src/galts_trade_api/exchange.py
@@ -24,8 +24,28 @@ class Exchange:
         self._markets: Dict[str, Market] = {}
 
     @property
+    def id(self):
+        return self._id
+
+    @property
     def tag(self):
         return self._tag
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def create_time(self):
+        return self._create_time
+
+    @property
+    def delete_time(self):
+        return self._delete_time
+
+    @property
+    def disable_time(self):
+        return self._disable_time
 
     def add_market(self, market: Market) -> None:
         if market.custom_tag in self._markets:
@@ -59,5 +79,29 @@ class Market:
         self._delete_time: Optional[datetime.datetime] = delete_time
 
     @property
+    def id(self):
+        return self._id
+
+    @property
     def custom_tag(self):
         return self._custom_tag
+
+    @property
+    def exchange_id(self):
+        return self._exchange_id
+
+    @property
+    def symbol_id(self):
+        return self._symbol_id
+
+    @property
+    def trade_endpoint(self):
+        return self._trade_endpoint
+
+    @property
+    def create_time(self):
+        return self._create_time
+
+    @property
+    def delete_time(self):
+        return self._delete_time

--- a/src/galts_trade_api/structlogger.py
+++ b/src/galts_trade_api/structlogger.py
@@ -1,0 +1,81 @@
+import logging
+import sys
+from typing import Dict, Mapping, Optional, TextIO
+
+import structlog
+import ujson
+from structlog.processors import _figure_out_exc_info
+
+__all__ = ['get_logger', 'configure_json_output', 'UltraJSONRenderer']
+
+
+def _shy_format_exc_info(_, __, event_dict: Dict) -> Mapping:
+    """
+    A version of `structlog.processors.format_exc_info` which doesn't dump a tracback.
+    Check http://www.structlog.org/en/19.1.0/processors.html for info about processors.
+    """
+    exc_info = event_dict.pop('exc_info', None)
+    if exc_info:
+        exc_tuple = _figure_out_exc_info(exc_info)
+        event_dict['exceptionClass'] = exc_tuple[0].__name__
+        event_dict['exceptionMessage'] = str(exc_tuple[1])
+    return event_dict
+
+
+class UltraJSONRenderer(structlog.processors.JSONRenderer):
+    def __init__(self, **dumps_kw):
+        self._dumps_kw = dumps_kw
+        self._dumps = ujson.dumps
+
+
+def configure_json_output(enable_unicode_decoder: bool = False, **json_dumps_kwargs) -> None:
+    """
+    Args:
+         json_dumps_kwargs: Optional arguments for JSON serializer. Useful value in development:
+            {'indent': 2}
+    """
+    if structlog.is_configured():
+        return
+
+    json_dumps_kwargs.setdefault('escape_forward_slashes', False)
+
+    processors = [
+        structlog.stdlib.filter_by_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.TimeStamper('iso', True),
+        structlog.processors.StackInfoRenderer(),
+        _shy_format_exc_info,
+    ]
+
+    if enable_unicode_decoder:
+        processors.append(structlog.processors.UnicodeDecoder())
+
+    processors.append(UltraJSONRenderer(**json_dumps_kwargs))
+
+    structlog.configure_once(
+        processors=processors,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        # Like http://www.structlog.org/en/19.1.0/performance.html advice
+        cache_logger_on_first_use=True
+    )
+
+
+def get_logger(
+    name: Optional[str] = None,
+    level: Optional[int] = logging.INFO,
+    stream: Optional[TextIO] = sys.stdout,
+    *args,
+    **kwargs
+) -> logging.Logger:
+    # To correct work of stdlib we should initialize the standard logger with the name before
+    # interaction with structlog
+    std_logger = logging.getLogger(name)
+    if level is not None:
+        std_logger.setLevel(level)
+    if stream is not None:
+        std_logger.addHandler(logging.StreamHandler(stream))
+
+    return structlog.get_logger(name, *args, **kwargs)

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -37,9 +37,9 @@ class Terminal:
     async def wait_exchange_entities_inited(self, timeout: float = 5.0) -> None:
         await wait_for(self._exchange_entities_inited.wait(), timeout)
 
-    async def init_exchange_entities(self) -> None:
-        await self.transport_factory.init_exchange_entities(
-            self._on_init_exchange_entities_response
+    async def get_exchange_entities(self) -> None:
+        await self.transport_factory.get_exchange_entities(
+            self._on_get_exchange_entities_response
         )
 
     async def auth_user(self, username: str, password: str) -> bool:
@@ -53,12 +53,12 @@ class Terminal:
         callback: OnPriceCallable,
         consume_keys: Optional[List[DepthConsumeKey]] = None
     ) -> None:
-        await self.transport_factory.get_depth_scraping_consumer(
+        await self.transport_factory.consume_price_depth(
             lambda event: callback(*event),
             consume_keys
         )
 
-    async def _on_init_exchange_entities_response(
+    async def _on_get_exchange_entities_response(
         self,
         data: MutableMapping[str, MutableMapping]
     ) -> None:
@@ -67,7 +67,7 @@ class Terminal:
         for prop in properties_to_fill:
             if prop not in data:
                 # @TODO Stop the process on this exception
-                raise KeyError(f'init_exchange_entities data have not required key "{prop}"')
+                raise KeyError(f'get_exchange_entities data have not required key "{prop}"')
 
             data[prop] = {k: v for k, v in data[prop].items() if not v['delete_time']}
 

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -46,11 +46,9 @@ class Terminal:
             self._on_init_exchange_entities_response
         )
 
-    # @TODO Cover
     def get_exchange(self, tag: str) -> Exchange:
         return self._exchanges[tag]
 
-    # @TODO Cover
     async def subscribe_to_prices(
         self,
         callback: OnPriceCallable,

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -76,13 +76,13 @@ class Terminal:
             if key in self._assets:
                 raise ValueError(f'Asset with tag "{key}" already exists')
 
-            self._assets[key] = Asset(self.transport_factory, **entity)
+            self._assets[key] = Asset(**entity)
 
         for id_, entity in data['symbols'].items():
             if id_ in self._symbols:
                 raise ValueError(f'Symbol with id {id_} already exists')
 
-            self._symbols[id_] = Symbol(self.transport_factory, **entity)
+            self._symbols[id_] = Symbol(**entity)
 
         exchanges_ids_map = {}
         for entity in data['exchanges'].values():
@@ -90,7 +90,7 @@ class Terminal:
             if key in self._exchanges:
                 raise ValueError(f'Exchange with tag "{key}" already exists')
 
-            exchange = Exchange(self.transport_factory, **entity)
+            exchange = Exchange(**entity)
             self._exchanges[key] = exchange
             exchanges_ids_map[entity['id']] = exchange
 
@@ -101,6 +101,6 @@ class Terminal:
                     f'No exchange with id {key} has been found for market with id {entity["id"]}'
                 )
 
-            exchanges_ids_map[key].add_market(Market(self.transport_factory, **entity))
+            exchanges_ids_map[key].add_market(Market(**entity))
 
         self._exchange_entities_inited.set()

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -1,18 +1,16 @@
+import datetime
 from asyncio import Event, wait_for
-from typing import Dict, MutableMapping, Optional
+from typing import Awaitable, Callable, Dict, List, MutableMapping, Optional
 
 from .asset import Asset, Symbol
 from .exchange import Exchange, Market
-from .transport import OnExceptionCallable, TransportFactory
+from .transport import DepthConsumeKey, TransportFactory
+
+OnPriceCallable = Callable[[str, str, str, datetime.datetime, List, List], Awaitable]
 
 
 class Terminal:
-    def __init__(
-        self,
-        transport: TransportFactory,
-        on_exception: Optional[OnExceptionCallable] = None
-    ):
-        self._on_exception = on_exception if on_exception else lambda: None
+    def __init__(self, transport: TransportFactory):
         self._transport_factory: TransportFactory = transport
         self._exchange_entities_inited = Event()
         self._exchanges: Dict[str, Exchange] = {}
@@ -27,8 +25,8 @@ class Terminal:
     def transport_factory(self, value):
         self._transport_factory = value
 
-    async def init_transport(self) -> None:
-        await self.transport_factory.init(self._on_exception)
+    async def init_transport(self, loop_debug: Optional[bool] = None) -> None:
+        await self.transport_factory.init(loop_debug)
 
     def shutdown_transport(self) -> None:
         self.transport_factory.shutdown()
@@ -44,55 +42,65 @@ class Terminal:
             self._on_init_exchange_entities_response
         )
 
-    async def _on_init_exchange_entities_response(
-        self,
-        event: MutableMapping[str, MutableMapping]
-    ) -> None:
-        properties_to_fill = ('exchanges', 'markets', 'symbols', 'assets')
-
-        for prop in properties_to_fill:
-            if prop not in event:
-                # @TODO Stop the process on this exception
-                raise KeyError(f'init_exchange_entities event have not required key "{prop}"')
-
-            event[prop] = {k: v for k, v in event[prop].items() if not v['delete_time']}
-
-        for data in event['assets'].values():
-            key = data['tag']
-            if key in self._assets:
-                raise ValueError(f'Asset with tag "{key}" already exists')
-
-            self._assets[key] = Asset(self.transport_factory, **data)
-
-        for id_, data in event['symbols'].items():
-            if id_ in self._symbols:
-                raise ValueError(f'Symbol with id {id_} already exists')
-
-            self._symbols[id_] = Symbol(self.transport_factory, **data)
-
-        exchanges_ids_map = {}
-        for data in event['exchanges'].values():
-            key = data['tag']
-            if key in self._exchanges:
-                raise ValueError(f'Exchange with tag "{key}" already exists')
-
-            exchange = Exchange(self.transport_factory, **data)
-            self._exchanges[key] = exchange
-            exchanges_ids_map[data['id']] = exchange
-
-        for data in event['markets'].values():
-            key = data['exchange_id']
-            if key not in exchanges_ids_map:
-                raise ValueError(
-                    f'No exchange with id {key} has been found for market with id {data["id"]}'
-                )
-
-            exchanges_ids_map[key].add_market(Market(self.transport_factory, **data))
-
-        self._exchange_entities_inited.set()
-
     async def auth_user(self, username: str, password: str) -> bool:
         return True
 
     def get_exchange(self, tag: str) -> Exchange:
         return self._exchanges[tag]
+
+    async def subscribe_to_prices(
+        self,
+        callback: OnPriceCallable,
+        consume_keys: Optional[List[DepthConsumeKey]] = None
+    ) -> None:
+        await self.transport_factory.get_depth_scraping_consumer(
+            lambda event: callback(*event),
+            consume_keys
+        )
+
+    async def _on_init_exchange_entities_response(
+        self,
+        data: MutableMapping[str, MutableMapping]
+    ) -> None:
+        properties_to_fill = ('exchanges', 'markets', 'symbols', 'assets')
+
+        for prop in properties_to_fill:
+            if prop not in data:
+                # @TODO Stop the process on this exception
+                raise KeyError(f'init_exchange_entities data have not required key "{prop}"')
+
+            data[prop] = {k: v for k, v in data[prop].items() if not v['delete_time']}
+
+        for entity in data['assets'].values():
+            key = entity['tag']
+            if key in self._assets:
+                raise ValueError(f'Asset with tag "{key}" already exists')
+
+            self._assets[key] = Asset(self.transport_factory, **entity)
+
+        for id_, entity in data['symbols'].items():
+            if id_ in self._symbols:
+                raise ValueError(f'Symbol with id {id_} already exists')
+
+            self._symbols[id_] = Symbol(self.transport_factory, **entity)
+
+        exchanges_ids_map = {}
+        for entity in data['exchanges'].values():
+            key = entity['tag']
+            if key in self._exchanges:
+                raise ValueError(f'Exchange with tag "{key}" already exists')
+
+            exchange = Exchange(self.transport_factory, **entity)
+            self._exchanges[key] = exchange
+            exchanges_ids_map[entity['id']] = exchange
+
+        for entity in data['markets'].values():
+            key = entity['exchange_id']
+            if key not in exchanges_ids_map:
+                raise ValueError(
+                    f'No exchange with id {key} has been found for market with id {entity["id"]}'
+                )
+
+            exchanges_ids_map[key].add_market(Market(self.transport_factory, **entity))
+
+        self._exchange_entities_inited.set()

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -1,6 +1,6 @@
 import datetime
 from asyncio import Event, wait_for
-from typing import Awaitable, Callable, Dict, List, MutableMapping, Optional
+from typing import Awaitable, Callable, Dict, List, Mapping, MutableMapping, Optional
 
 from .asset import Asset, Symbol
 from .exchange import Exchange, Market
@@ -37,9 +37,9 @@ class Terminal:
     async def wait_exchange_entities_inited(self, timeout: float = 5.0) -> None:
         await wait_for(self._exchange_entities_inited.wait(), timeout)
 
-    async def get_exchange_entities(self) -> None:
+    async def init_exchange_entities(self) -> None:
         await self.transport_factory.get_exchange_entities(
-            self._on_get_exchange_entities_response
+            self._on_init_exchange_entities_response
         )
 
     async def auth_user(self, username: str, password: str) -> bool:
@@ -58,10 +58,7 @@ class Terminal:
             consume_keys
         )
 
-    async def _on_get_exchange_entities_response(
-        self,
-        data: MutableMapping[str, MutableMapping]
-    ) -> None:
+    async def _on_init_exchange_entities_response(self, data: MutableMapping[str, Mapping]) -> None:
         properties_to_fill = ('exchanges', 'markets', 'symbols', 'assets')
 
         for prop in properties_to_fill:

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -77,6 +77,17 @@ class Terminal:
             self._assets[entity['tag']] = Asset(**entity)
 
         for id_, entity in data['symbols'].items():
+            if entity['base_asset_id'] not in data['assets']:
+                raise ValueError(
+                    f"No base asset with id {entity['base_asset_id']} "
+                    f"has been found for symbol with id {id_}"
+                )
+            if entity['quote_asset_id'] not in data['assets']:
+                raise ValueError(
+                    f"No quote asset with id {entity['quote_asset_id']} "
+                    f"has been found for symbol with id {id_}"
+                )
+
             self._symbols[id_] = Symbol(**entity)
 
         all_exchanges_tags = [entity['tag'] for entity in data['exchanges'].values()]
@@ -91,12 +102,17 @@ class Terminal:
             exchanges_ids_map[entity['id']] = exchange
 
         for entity in data['markets'].values():
-            key = entity['exchange_id']
-            if key not in exchanges_ids_map:
+            if entity['exchange_id'] not in exchanges_ids_map:
                 raise ValueError(
-                    f'No exchange with id {key} has been found for market with id {entity["id"]}'
+                    f"No exchange with id {entity['exchange_id']} "
+                    f"has been found for market with id {entity['id']}"
+                )
+            if entity['symbol_id'] not in data['symbols']:
+                raise ValueError(
+                    f"No symbol with id {entity['symbol_id']} "
+                    f"has been found for market with id {entity['id']}"
                 )
 
-            exchanges_ids_map[key].add_market(Market(**entity))
+            exchanges_ids_map[entity['exchange_id']].add_market(Market(**entity))
 
         self._exchange_entities_inited.set()

--- a/src/galts_trade_api/tools.py
+++ b/src/galts_trade_api/tools.py
@@ -1,4 +1,5 @@
 import pickle
+from typing import Dict, Tuple
 
 
 class Singleton(type):
@@ -22,7 +23,7 @@ class Singleton(type):
         return cls._instances[key]
 
     @classmethod
-    def _calculate_args_hash(mcs, args, kwargs):
+    def _calculate_args_hash(mcs, args: Tuple, kwargs: Dict) -> int:
         filtered_args = [args[i] for i in range(len(args)) if i in mcs._hash_args]
         filtered_kwargs = {k: v for k, v in kwargs.items() if k in mcs._hash_kwargs}
         hash_source = (filtered_args, filtered_kwargs)

--- a/src/galts_trade_api/tools.py
+++ b/src/galts_trade_api/tools.py
@@ -3,6 +3,13 @@ from typing import Dict, Tuple
 
 
 class Singleton(type):
+    """
+    Requirement to return an old object are determined by calculating hash of a constructor call
+    arguments. One issue with this logic is that if the constructor in second time was called
+    with keyword-style of some arguments, the logic will fail if it was called with only
+    position-style of the same arguments. In this situation a new object will be created.
+    """
+
     _instances = {}
     _hash_args = []
     _hash_kwargs = {}

--- a/src/galts_trade_api/tools.py
+++ b/src/galts_trade_api/tools.py
@@ -1,5 +1,5 @@
 import pickle
-from typing import Dict, Tuple
+from typing import Dict, Sequence, Set, Tuple
 
 
 class Singleton(type):
@@ -38,3 +38,7 @@ class Singleton(type):
         result = hash(pickle.dumps(hash_source, protocol=pickle.HIGHEST_PROTOCOL))
 
         return result
+
+
+def find_duplicates_in_list(source_list: Sequence) -> Set:
+    return set([tag for tag in source_list if source_list.count(tag) > 1])

--- a/src/galts_trade_api/transport/__init__.py
+++ b/src/galts_trade_api/transport/__init__.py
@@ -82,6 +82,8 @@ class PipeResponseRouter:
         if request not in self._consumers:
             return
 
+        # Don't store the sub-tasks because we don't want to cancel them if self.start() has been
+        # cancelled.
         asyncio.create_task(self._consumers[request].send(response))
 
 

--- a/src/galts_trade_api/transport/__init__.py
+++ b/src/galts_trade_api/transport/__init__.py
@@ -93,14 +93,14 @@ class TransportFactory(ABC):
         pass
 
     @abstractmethod
-    async def init_exchange_entities(
+    async def get_exchange_entities(
         self,
         on_response: Callable[..., Awaitable]
     ) -> MessageConsumerCollection:
         pass
 
     @abstractmethod
-    async def get_depth_scraping_consumer(
+    async def consume_price_depth(
         self,
         on_response: Callable[..., Awaitable],
         consume_keys: Optional[List[DepthConsumeKey]] = None

--- a/src/galts_trade_api/transport/__init__.py
+++ b/src/galts_trade_api/transport/__init__.py
@@ -67,7 +67,7 @@ class PipeResponseRouter:
                 raise message[0]
 
             if len(message) != 2:
-                raise ValueError('Pipe response message can contain exactly 2 elements')
+                raise ValueError('Pipe response message should contain exactly 2 elements')
 
             request, response = message
             self._dispatch(request, response)

--- a/src/galts_trade_api/transport/__init__.py
+++ b/src/galts_trade_api/transport/__init__.py
@@ -63,7 +63,7 @@ class PipeResponseRouter:
             if not isinstance(message, Sequence):
                 raise ValueError('Pipe response message should be an object with indexing')
 
-            if isinstance(message[0], Exception):
+            if len(message) == 1 and isinstance(message[0], Exception):
                 raise message[0]
 
             if len(message) != 2:

--- a/src/galts_trade_api/transport/__init__.py
+++ b/src/galts_trade_api/transport/__init__.py
@@ -35,7 +35,11 @@ class MessageConsumerCollection:
     async def send(self, data: Any) -> None:
         coroutines = [consumer(data) for consumer in self._consumers]
 
-        await asyncio.gather(*coroutines)
+        tasks_result = await asyncio.gather(*coroutines, return_exceptions=True)
+
+        for result in tasks_result:
+            if isinstance(result, BaseException):
+                raise result
 
 
 class PipeRequest:

--- a/src/galts_trade_api/transport/grpc_utils.py
+++ b/src/galts_trade_api/transport/grpc_utils.py
@@ -44,7 +44,7 @@ def message_to_dict(
     to datetime.
     """
 
-    def pythonify_value(field_name: str, field_value):
+    def pythonify_value(field_name: str, field_value) -> Any:
         if isinstance(field_value, Timestamp):
             dt = field_value.ToDatetime()
             if convert_datetime_to_utc:
@@ -72,7 +72,7 @@ def message_to_dict(
         return local_msg.DESCRIPTOR.fields_by_name[field_name].enum_type. \
             values_by_number.get(field_value).name
 
-    def get_actual_field_value(field_name: str, local_msg: Message):
+    def get_actual_field_value(field_name: str, local_msg: Message) -> Any:
         for field_descriptor, field_value in local_msg.ListFields():
             if field_descriptor.name == field_name:
                 if isinstance(field_value, RepeatedCompositeContainer):
@@ -125,7 +125,7 @@ def message_to_dict(
 OptionalGrpcTimeout = Optional[Union[str, int, float]]
 
 
-def correct_timeout(timeout: OptionalGrpcTimeout = None) -> Union[float, None]:
+def correct_timeout(timeout: OptionalGrpcTimeout = None) -> Optional[float]:
     if timeout is not None:
         timeout = float(timeout)
         if timeout <= 0:

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -99,7 +99,8 @@ class RealTransportFactory(TransportFactory):
         exchange_info_dsn: Optional[str] = None,
         exchange_info_get_entities_timeout: float = 5.0,
         depth_scraping_queue_dsn: Optional[str] = None,
-        depth_scraping_queue_exchange: Optional[str] = None
+        depth_scraping_queue_exchange: Optional[str] = None,
+        process_ready_timeout: float = 2,
     ):
         super().__init__()
         self._process: Optional[Process] = None
@@ -115,6 +116,7 @@ class RealTransportFactory(TransportFactory):
         self._exchange_info_get_entities_timeout = float(exchange_info_get_entities_timeout)
         self._depth_scraping_queue_dsn = sanity_string(depth_scraping_queue_dsn)
         self._depth_scraping_queue_exchange = sanity_string(depth_scraping_queue_exchange)
+        self._process_ready_timeout = float(process_ready_timeout)
 
     async def init(self, loop_debug: Optional[bool] = None) -> None:
         if self._process:
@@ -127,7 +129,7 @@ class RealTransportFactory(TransportFactory):
         )
         self._process.start()
 
-        if not self._process_ready.wait(2):
+        if not self._process_ready.wait(self._process_ready_timeout):
             raise RuntimeError('Failed to initialize RealTransportFactory in time')
 
         self._response_router = PipeResponseRouter(self._parent_connection)

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -230,7 +230,7 @@ class RealTransportProcess(Process):
     async def init_exchange_entities(self, request: InitExchangeEntitiesRequest) -> None:
         client = ExchangeInfoClient.factory(request.dsn, timeout_get_entities=request.timeout)
         entities = client.get_entities(generate_request_id())
-        self._response_owner_request(request, entities)
+        self._respond_to_owner_request(request, entities)
 
         client.destroy()
 
@@ -265,7 +265,7 @@ class RealTransportProcess(Process):
 
         return self._handlers[request_type]
 
-    def _response_owner_request(self, request: PipeRequest, content: Any):
+    def _respond_to_owner_request(self, request: PipeRequest, content: Any):
         self._connection.send([request, content])
 
     def _depth_scraping_callback(
@@ -283,4 +283,4 @@ class RealTransportProcess(Process):
             body['depth']['asks'],
         ]
 
-        self._response_owner_request(request, args)
+        self._respond_to_owner_request(request, args)

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -94,33 +94,32 @@ class RabbitConsumer:
 
 
 class RealTransportFactory(TransportFactory):
-    def __init__(self):
-        super().__init__()
-        self._process: Optional[Process] = None
-        self._process_ready = Event()
-        self._parent_connection, self._child_connection = Pipe()
-        self._response_router: Optional[PipeResponseRouter] = None
-        self._exchange_info_dsn: Optional[str] = None
-        self._exchange_info_get_entities_timeout: float = 5.0
-        self._depth_scraping_queue_dsn: Optional[str] = None
-        self._depth_scraping_queue_exchange: Optional[str] = None
-
-    def configure_endpoints(
+    def __init__(
         self,
         exchange_info_dsn: Optional[str] = None,
         exchange_info_get_entities_timeout: Optional[float] = None,
         depth_scraping_queue_dsn: Optional[str] = None,
         depth_scraping_queue_exchange: Optional[str] = None,
-    ) -> None:
+    ):
+        super().__init__()
+        self._process: Optional[Process] = None
+        self._process_ready = Event()
+        self._parent_connection, self._child_connection = Pipe()
+        self._response_router: Optional[PipeResponseRouter] = None
+
         def sanity_string(value: Optional[str]) -> Optional[str]:
             if value is not None:
                 return str(value).strip()
 
-        self._exchange_info_dsn = sanity_string(exchange_info_dsn)
+        self._exchange_info_dsn: Optional[str] = sanity_string(exchange_info_dsn)
+        self._depth_scraping_queue_dsn: Optional[str] = sanity_string(depth_scraping_queue_dsn)
+        self._depth_scraping_queue_exchange: Optional[str] = sanity_string(
+            depth_scraping_queue_exchange
+        )
+
+        self._exchange_info_get_entities_timeout: float = 5.0
         if exchange_info_get_entities_timeout is not None:
             self._exchange_info_get_entities_timeout = float(exchange_info_get_entities_timeout)
-        self._depth_scraping_queue_dsn = sanity_string(depth_scraping_queue_dsn)
-        self._depth_scraping_queue_exchange = sanity_string(depth_scraping_queue_exchange)
 
     async def init(self, loop_debug: Optional[bool] = None) -> None:
         if self._process:

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -97,9 +97,9 @@ class RealTransportFactory(TransportFactory):
     def __init__(
         self,
         exchange_info_dsn: Optional[str] = None,
-        exchange_info_get_entities_timeout: Optional[float] = None,
+        exchange_info_get_entities_timeout: float = 5.0,
         depth_scraping_queue_dsn: Optional[str] = None,
-        depth_scraping_queue_exchange: Optional[str] = None,
+        depth_scraping_queue_exchange: Optional[str] = None
     ):
         super().__init__()
         self._process: Optional[Process] = None
@@ -111,15 +111,10 @@ class RealTransportFactory(TransportFactory):
             if value is not None:
                 return str(value).strip()
 
-        self._exchange_info_dsn: Optional[str] = sanity_string(exchange_info_dsn)
-        self._depth_scraping_queue_dsn: Optional[str] = sanity_string(depth_scraping_queue_dsn)
-        self._depth_scraping_queue_exchange: Optional[str] = sanity_string(
-            depth_scraping_queue_exchange
-        )
-
-        self._exchange_info_get_entities_timeout: float = 5.0
-        if exchange_info_get_entities_timeout is not None:
-            self._exchange_info_get_entities_timeout = float(exchange_info_get_entities_timeout)
+        self._exchange_info_dsn = sanity_string(exchange_info_dsn)
+        self._exchange_info_get_entities_timeout = float(exchange_info_get_entities_timeout)
+        self._depth_scraping_queue_dsn = sanity_string(depth_scraping_queue_dsn)
+        self._depth_scraping_queue_exchange = sanity_string(depth_scraping_queue_exchange)
 
     async def init(self, loop_debug: Optional[bool] = None) -> None:
         if self._process:

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -96,11 +96,11 @@ class RabbitConsumer:
 class RealTransportFactory(TransportFactory):
     def __init__(
         self,
-        exchange_info_dsn: Optional[str] = None,
+        exchange_info_dsn: str,
+        depth_scraping_queue_dsn: str,
+        depth_scraping_queue_exchange: str,
         exchange_info_get_entities_timeout: float = 5.0,
-        depth_scraping_queue_dsn: Optional[str] = None,
-        depth_scraping_queue_exchange: Optional[str] = None,
-        process_ready_timeout: float = 2,
+        process_ready_timeout: float = 2.0,
     ):
         super().__init__()
         self._process: Optional[Process] = None
@@ -108,9 +108,8 @@ class RealTransportFactory(TransportFactory):
         self._parent_connection, self._child_connection = Pipe()
         self._response_router: Optional[PipeResponseRouter] = None
 
-        def sanity_string(value: Optional[str]) -> Optional[str]:
-            if value is not None:
-                return str(value).strip()
+        def sanity_string(value: str) -> str:
+            return str(value).strip()
 
         self._exchange_info_dsn = sanity_string(exchange_info_dsn)
         self._exchange_info_get_entities_timeout = float(exchange_info_get_entities_timeout)

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -132,6 +132,9 @@ class RealTransportFactory(TransportFactory):
         )
         self._process.start()
 
+        if not self._process_ready.wait(2):
+            raise RuntimeError('Failed to initialize RealTransportFactory in time')
+
         self._response_router = PipeResponseRouter(self._parent_connection)
         task = asyncio.create_task(self._response_router.start())
 
@@ -145,9 +148,6 @@ class RealTransportFactory(TransportFactory):
                 raise t.exception()
 
         task.add_done_callback(task_done_cb)
-
-        if not self._process_ready.wait(2):
-            raise RuntimeError('Failed to initialize RealTransportFactory in time')
 
     def shutdown(self) -> None:
         if self._process:

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -254,6 +254,9 @@ class RealTransportProcess(Process):
             request = self._connection.recv()
 
             handler = self._find_handler_for_request(request)
+            # @TODO The tasks should be collected for cancellation when this main task has been
+            # cancelled. But when I've tried to done this I've got Segmentation fault from
+            # unit-tests. May be it depends on Python version.
             asyncio.create_task(handler(request))
 
     async def _get_exchange_entities(self, request: GetExchangeEntitiesRequest) -> None:

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -208,7 +208,7 @@ class RealTransportProcess(Process):
         run_program_forever(self.main, loop_debug=self._loop_debug)
 
     async def main(self, program_env: AsyncProgramEnv) -> None:
-        def exception_handler(local_loop: asyncio.AbstractEventLoop, context: Dict) -> None:
+        def exception_handler(_, context: Dict) -> None:
             if 'exception' in context:
                 self._notify_owner_process(context['exception'])
 

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -256,7 +256,6 @@ class RealTransportProcess(Process):
             handler = self._find_handler_for_request(request)
             asyncio.create_task(handler(request))
 
-    # @TODO Cover
     async def _get_exchange_entities(self, request: GetExchangeEntitiesRequest) -> None:
         client = ExchangeInfoClient.factory(request.dsn, timeout_get_entities=request.timeout)
         entities = client.get_entities(generate_request_id())
@@ -264,7 +263,6 @@ class RealTransportProcess(Process):
 
         client.destroy()
 
-    # @TODO Cover
     async def _consume_price_depth(self, request: ConsumePriceDepthRequest) -> None:
         connection = RabbitConnection(request.dsn)
         channel = await connection.create_channel(100)

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -220,6 +220,10 @@ class RealTransportProcess(Process):
             ConsumeDepthScrapingRequest: self.consume_depth_scraping,
         }
 
+    @property
+    def poll_delay(self):
+        return self._poll_delay
+
     def run(self) -> None:
         run_program_forever(self.main, loop_debug=self._loop_debug)
 
@@ -234,7 +238,7 @@ class RealTransportProcess(Process):
 
         while True:
             if not self._connection.poll():
-                await asyncio.sleep(self._poll_delay)
+                await asyncio.sleep(self.poll_delay)
                 continue
 
             request = self._connection.recv()

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -46,7 +46,7 @@ class RabbitConnection(
         return self._connection
 
     async def create_channel(self, prefetch_count: int = 100) -> aio_pika.Channel:
-        if not self._connection:
+        if self._connection is None:
             self._connection = await aio_pika.connect_robust(self._dsn)
 
         channel = await self._connection.channel()

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -55,7 +55,7 @@ class RabbitConnection(
         return channel
 
 
-class RabbitQueueConsumer:
+class RabbitConsumer:
     def __init__(
         self,
         channel: aio_pika.Channel,
@@ -69,12 +69,12 @@ class RabbitQueueConsumer:
         self._queue: Optional[aio_pika.Queue] = None
 
     @property
-    def exchange_name(self):
-        return self._exchange_name
-
-    @property
     def channel(self):
         return self._channel
+
+    @property
+    def exchange_name(self):
+        return self._exchange_name
 
     @property
     def exchange(self):
@@ -238,7 +238,7 @@ class RealTransportProcess(Process):
         connection = RabbitConnection(request.dsn)
         channel = await connection.create_channel(100)
         cb = partial(self._depth_scraping_callback, request)
-        consumer = RabbitQueueConsumer(channel, request.exchange, cb)
+        consumer = RabbitConsumer(channel, request.exchange, cb)
         queue = await consumer.create_queue()
 
         if not request.consume_keys:

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -288,8 +288,10 @@ class RealTransportProcess(Process):
         # of the exception. Otherwise a framework user will see undesired spam about
         # pickling RLock etc in logs.
         wrapped_exception = TransportFactoryException('An error in the transport process')
+        # Unfortunately this line has no side-effects in Python 3.7 because this attribute
+        # won't be packed by Connection.send() therefore cross-Connection.recv() will unpack
+        # the data without the value for this attribute. So we don't have real wrapping here.
         wrapped_exception.__cause__ = original_exception
-
         self._connection.send([wrapped_exception])
 
     def _find_handler_for_request(self, request: PipeRequest) -> Callable[..., Awaitable]:

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -108,8 +108,7 @@ class RealTransportFactory(TransportFactory):
         self._parent_connection, self._child_connection = Pipe()
         self._response_router: Optional[PipeResponseRouter] = None
 
-        def sanity_string(value: str) -> str:
-            return str(value).strip()
+        def sanity_string(value: str) -> str: return str(value).strip()
 
         self._exchange_info_dsn = sanity_string(exchange_info_dsn)
         self._exchange_info_get_entities_timeout = float(exchange_info_get_entities_timeout)

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -118,6 +118,26 @@ class RealTransportFactory(TransportFactory):
         self._depth_scraping_queue_exchange = sanity_string(depth_scraping_queue_exchange)
         self._process_ready_timeout = float(process_ready_timeout)
 
+    @property
+    def exchange_info_dsn(self):
+        return self._exchange_info_dsn
+
+    @property
+    def exchange_info_get_entities_timeout(self):
+        return self._exchange_info_get_entities_timeout
+
+    @property
+    def depth_scraping_queue_dsn(self):
+        return self._depth_scraping_queue_dsn
+
+    @property
+    def depth_scraping_queue_exchange(self):
+        return self._depth_scraping_queue_exchange
+
+    @property
+    def process_ready_timeout(self):
+        return self._process_ready_timeout
+
     async def init(self, loop_debug: Optional[bool] = None) -> None:
         if self._process:
             raise RuntimeError('A process for RealTransportFactory should be created only once')
@@ -129,7 +149,7 @@ class RealTransportFactory(TransportFactory):
         )
         self._process.start()
 
-        if not self._process_ready.wait(self._process_ready_timeout):
+        if not self._process_ready.wait(self.process_ready_timeout):
             raise RuntimeError('Failed to initialize RealTransportFactory in time')
 
         self._response_router = PipeResponseRouter(self._parent_connection)
@@ -155,8 +175,8 @@ class RealTransportFactory(TransportFactory):
         on_response: Callable[..., Awaitable]
     ) -> MessageConsumerCollection:
         request = InitExchangeEntitiesRequest(
-            self._exchange_info_dsn,
-            self._exchange_info_get_entities_timeout
+            self.exchange_info_dsn,
+            self.exchange_info_get_entities_timeout
         )
         result = self._response_router.prepare_consumers_of_response(request)
         result.add_consumer(on_response)
@@ -170,8 +190,8 @@ class RealTransportFactory(TransportFactory):
         consume_keys: Optional[List[DepthConsumeKey]] = None
     ) -> MessageConsumerCollection:
         request = ConsumeDepthScrapingRequest(
-            self._depth_scraping_queue_dsn,
-            self._depth_scraping_queue_exchange,
+            self.depth_scraping_queue_dsn,
+            self.depth_scraping_queue_exchange,
             frozenset(consume_keys)
         )
         result = self._response_router.prepare_consumers_of_response(request)

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -88,9 +88,9 @@ class RabbitConsumer:
         self._exchange = await self.channel.declare_exchange(self._exchange_name, passive=True)
         self._queue = await self.channel.declare_queue(exclusive=True)
 
-        await self._queue.consume(self._on_message, no_ack=True)
+        await self.queue.consume(self._on_message, no_ack=True)
 
-        return self._queue
+        return self.queue
 
 
 class RealTransportFactory(TransportFactory):

--- a/tests/asset_test.py
+++ b/tests/asset_test.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -31,7 +31,7 @@ class TestAsset:
         'prop, arg_value, expected_value',
         fixture_asset_constructor_cast_properties()
     )
-    def test_constructor_cast_properties(self, prop: str, arg_value, expected_value):
+    def test_constructor_cast_properties(self, prop: str, arg_value: Any, expected_value: Any):
         instance = self._factory_asset(**{prop: arg_value})
 
         assert getattr(instance, prop) == expected_value

--- a/tests/asset_test.py
+++ b/tests/asset_test.py
@@ -67,7 +67,7 @@ class TestSymbol:
         'prop, arg_value, expected_value',
         fixture_symbol_constructor_cast_properties()
     )
-    def test_constructor_cast_properties(self, prop: str, arg_value, expected_value):
+    def test_constructor_cast_properties(self, prop: str, arg_value: Any, expected_value: Any):
         instance = self._factory_symbol(**{prop: arg_value})
 
         assert getattr(instance, prop) == expected_value

--- a/tests/asset_test.py
+++ b/tests/asset_test.py
@@ -1,0 +1,74 @@
+import datetime
+from typing import Optional
+
+import pytest
+
+from galts_trade_api.asset import Asset, Symbol
+
+
+def fixture_asset_constructor_cast_properties():
+    # String properties
+    for prop in ('tag', 'name',):
+        yield prop, 1, '1'
+        yield prop, 2.0, '2.0'
+        yield prop, False, 'False'
+        yield prop, ' test ', 'test'
+
+    # Integer properties
+    for prop in ('id', 'precision',):
+        yield prop, '-1', -1
+        yield prop, '1', 1
+        yield prop, 2.0, 2
+
+
+class TestAsset:
+    @pytest.mark.parametrize(
+        'prop, arg_value, expected_value',
+        fixture_asset_constructor_cast_properties()
+    )
+    def test_constructor_cast_properties(self, prop: str, arg_value, expected_value):
+        instance = self._factory_asset(**{prop: arg_value})
+
+        assert getattr(instance, prop) == expected_value
+
+    @classmethod
+    def _factory_asset(
+        cls,
+        id: Optional[int] = 1,
+        tag: Optional[str] = 'tag',
+        name: Optional[str] = 'name',
+        precision: Optional[int] = 2,
+        create_time: Optional[datetime.datetime] = datetime.datetime.now(),
+        delete_time: Optional[datetime.datetime] = datetime.datetime.now()
+    ) -> Asset:
+        return Asset(id, tag, name, precision, create_time, delete_time)
+
+
+def fixture_symbol_constructor_cast_properties():
+    # Integer properties
+    for prop in ('id', 'base_asset_id', 'quote_asset_id',):
+        yield prop, '-1', -1
+        yield prop, '1', 1
+        yield prop, 2.0, 2
+
+
+class TestSymbol:
+    @pytest.mark.parametrize(
+        'prop, arg_value, expected_value',
+        fixture_symbol_constructor_cast_properties()
+    )
+    def test_constructor_cast_properties(self, prop: str, arg_value, expected_value):
+        instance = self._factory_symbol(**{prop: arg_value})
+
+        assert getattr(instance, prop) == expected_value
+
+    @classmethod
+    def _factory_symbol(
+        cls,
+        id: Optional[int] = 1,
+        base_asset_id: Optional[int] = 5,
+        quote_asset_id: Optional[int] = 6,
+        create_time: Optional[datetime.datetime] = datetime.datetime.now(),
+        delete_time: Optional[datetime.datetime] = datetime.datetime.now()
+    ) -> Symbol:
+        return Symbol(id, base_asset_id, quote_asset_id, create_time, delete_time)

--- a/tests/asset_test.py
+++ b/tests/asset_test.py
@@ -20,6 +20,11 @@ def fixture_asset_constructor_cast_properties():
         yield prop, '1', 1
         yield prop, 2.0, 2
 
+    # Time properties
+    for prop in ('create_time', 'delete_time',):
+        now = datetime.datetime.now()
+        yield prop, now, now
+
 
 class TestAsset:
     @pytest.mark.parametrize(
@@ -50,6 +55,11 @@ def fixture_symbol_constructor_cast_properties():
         yield prop, '-1', -1
         yield prop, '1', 1
         yield prop, 2.0, 2
+
+    # Time properties
+    for prop in ('create_time', 'delete_time',):
+        now = datetime.datetime.now()
+        yield prop, now, now
 
 
 class TestSymbol:

--- a/tests/asyncio_helper_test.py
+++ b/tests/asyncio_helper_test.py
@@ -39,7 +39,7 @@ class TestShutdown:
         logger_mock.debug.assert_called_once_with(
             'Cancelling outstanding tasks',
             process_id=ANY,
-            amount=0
+            count=0
         )
 
     @pytest.mark.asyncio
@@ -76,7 +76,7 @@ class TestShutdown:
         logger_mock.debug.assert_called_once_with(
             'Cancelling outstanding tasks',
             process_id=ANY,
-            amount=3
+            count=3
         )
 
 

--- a/tests/asyncio_helper_test.py
+++ b/tests/asyncio_helper_test.py
@@ -5,7 +5,8 @@ from unittest.mock import ANY, Mock
 
 import pytest
 
-from galts_trade_api.asyncio_helper import AsyncProgramEnv, run_program_forever, signal_handler
+from galts_trade_api.asyncio_helper import AsyncProgramEnv, run_program_forever, shutdown, \
+    signal_handler
 from .utils import AsyncMock
 
 
@@ -23,6 +24,60 @@ def test_signal_handler_log_and_shutdown(mocker):
         process_id=ANY,
         signal='SIGTERM'
     )
+
+
+class TestShutdown:
+    @pytest.mark.asyncio
+    async def test_log_and_stop_loop(self, mocker):
+        logger_mock = mocker.patch('galts_trade_api.asyncio_helper.logger')
+        loop = Mock(spec_set=asyncio.AbstractEventLoop)
+
+        await shutdown(loop)
+
+        loop.stop.assert_called_once()
+        logger_mock.info.assert_called_once_with('Shutting down', process_id=ANY)
+        logger_mock.debug.assert_called_once_with(
+            'Cancelling outstanding tasks',
+            process_id=ANY,
+            amount=0
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancel_tasks(self, mocker):
+        logger_mock = mocker.patch('galts_trade_api.asyncio_helper.logger')
+        loop = Mock(spec_set=asyncio.AbstractEventLoop)
+        current_task_mock = mocker.patch('asyncio.current_task', autospec=True)
+        task1 = Mock(spec_set=asyncio.Task)
+        task1().cancelled.return_value = True
+        task2 = Mock(spec_set=asyncio.Task)
+        task2().cancelled.return_value = False
+        task2().exception.return_value = None
+        task3 = Mock(spec_set=asyncio.Task)
+        task3().cancelled.return_value = False
+        task3_exception = Exception('exception in task')
+        task3().exception.return_value = task3_exception
+        all_tasks_mock = mocker.patch('asyncio.all_tasks', autospec=True)
+        all_tasks_mock.return_value = [task1(), task2(), task3()]
+        gather_mock = mocker.patch('asyncio.gather', new_callable=AsyncMock)
+
+        await shutdown(loop)
+
+        all_tasks_mock.assert_called_once_with(loop)
+        current_task_mock.assert_called_with(loop)
+        task1().cancel.assert_called_with()
+        task2().cancel.assert_called_with()
+        task3().cancel.assert_called_with()
+        gather_mock.assert_called_with(task1(), task2(), task3(), return_exceptions=True, loop=loop)
+        loop.default_exception_handler.assert_called_once_with({
+            'message': 'Unhandled exception during shutdown',
+            'exception': task3_exception,
+            'task': task3(),
+        })
+        logger_mock.debug.assert_called_once_with(
+            'Cancelling outstanding tasks',
+            process_id=ANY,
+            amount=3
+        )
 
 
 def fixture_setup_loop_by_arguments():

--- a/tests/asyncio_helper_test.py
+++ b/tests/asyncio_helper_test.py
@@ -1,0 +1,79 @@
+import asyncio
+from asyncio import Event
+from unittest.mock import ANY, Mock
+
+import pytest
+
+from galts_trade_api.asyncio_helper import AsyncProgramEnv
+from .utils import AsyncMock
+
+
+def fixture_exception_handler_patch_success():
+    yield None
+    yield lambda: None
+
+
+def fixture_exception_handler_patch_exception_for_wrong_type():
+    yield 1
+    yield 2.0
+    yield 'test'
+
+
+class TestAsyncProgramEnv:
+    def test_constructor_dont_init_patch(self):
+        env = AsyncProgramEnv()
+
+        assert env.exception_handler_patch is None
+
+    @pytest.mark.parametrize('value', fixture_exception_handler_patch_success())
+    def test_exception_handler_patch_success(self, value):
+        env = AsyncProgramEnv()
+
+        env.exception_handler_patch = value
+
+        assert env.exception_handler_patch is value
+
+    @pytest.mark.parametrize('value', fixture_exception_handler_patch_exception_for_wrong_type())
+    def test_exception_handler_patch_exception_for_wrong_type(self, value):
+        env = AsyncProgramEnv()
+
+        with pytest.raises(TypeError, match='should be a callable or None'):
+            env.exception_handler_patch = value
+
+    @pytest.mark.asyncio
+    async def test_exception_handler_log_and_shutdown(self, mocker):
+        logger_mock = mocker.patch('galts_trade_api.asyncio_helper.logger')
+        shutdown_mock = mocker.patch(
+            'galts_trade_api.asyncio_helper.shutdown',
+            new_callable=AsyncMock
+        )
+        loop = asyncio.get_running_loop()
+        mocker.patch.object(loop, 'default_exception_handler')
+        context = {'test': 100}
+
+        env = AsyncProgramEnv()
+        env.exception_handler(loop, context)
+        await asyncio.sleep(0.001)
+
+        loop.default_exception_handler.assert_called_once_with(context)
+        shutdown_mock.assert_called_once_with(loop)
+
+        logger_mock.info.assert_called_once_with('Caught exception', process_id=ANY)
+
+    @pytest.mark.asyncio
+    async def test_exception_handler_call_patch(self, mocker):
+        mocker.patch('galts_trade_api.asyncio_helper.shutdown')
+        is_called = Event()
+
+        def patch(local_loop, local_context):
+            is_called.set()
+            assert local_loop is loop
+            assert local_context is context
+
+        loop = Mock(spec_set=asyncio.AbstractEventLoop)
+        context = {}
+        env = AsyncProgramEnv()
+        env.exception_handler_patch = patch
+        env.exception_handler(loop, context)
+
+        assert is_called.is_set()

--- a/tests/asyncio_helper_test.py
+++ b/tests/asyncio_helper_test.py
@@ -86,10 +86,7 @@ def fixture_setup_loop_by_arguments():
 
 
 class TestRunProgramForever:
-    @pytest.mark.parametrize(
-        'loop_debug, handle_signals',
-        fixture_setup_loop_by_arguments()
-    )
+    @pytest.mark.parametrize('loop_debug, handle_signals', fixture_setup_loop_by_arguments())
     def test_setup_loop_by_arguments(self, mocker, loop_debug, handle_signals):
         logger_mock = mocker.patch('galts_trade_api.asyncio_helper.logger')
         env_mock = mocker.patch('galts_trade_api.asyncio_helper.AsyncProgramEnv')

--- a/tests/asyncio_helper_test.py
+++ b/tests/asyncio_helper_test.py
@@ -47,31 +47,31 @@ class TestShutdown:
         logger_mock = mocker.patch('galts_trade_api.asyncio_helper.logger')
         loop = Mock(spec_set=asyncio.AbstractEventLoop)
         current_task_mock = mocker.patch('asyncio.current_task', autospec=True)
-        task1 = Mock(spec_set=asyncio.Task)
-        task1().cancelled.return_value = True
-        task2 = Mock(spec_set=asyncio.Task)
-        task2().cancelled.return_value = False
-        task2().exception.return_value = None
-        task3 = Mock(spec_set=asyncio.Task)
-        task3().cancelled.return_value = False
+        task1 = Mock(spec_set=asyncio.Task).return_value
+        task1.cancelled.return_value = True
+        task2 = Mock(spec_set=asyncio.Task).return_value
+        task2.cancelled.return_value = False
+        task2.exception.return_value = None
+        task3 = Mock(spec_set=asyncio.Task).return_value
+        task3.cancelled.return_value = False
         task3_exception = Exception('exception in task')
-        task3().exception.return_value = task3_exception
+        task3.exception.return_value = task3_exception
         all_tasks_mock = mocker.patch('asyncio.all_tasks', autospec=True)
-        all_tasks_mock.return_value = [task1(), task2(), task3()]
+        all_tasks_mock.return_value = [task1, task2, task3]
         gather_mock = mocker.patch('asyncio.gather', new_callable=AsyncMock)
 
         await shutdown(loop)
 
         all_tasks_mock.assert_called_once_with(loop)
         current_task_mock.assert_called_with(loop)
-        task1().cancel.assert_called_with()
-        task2().cancel.assert_called_with()
-        task3().cancel.assert_called_with()
-        gather_mock.assert_called_with(task1(), task2(), task3(), return_exceptions=True, loop=loop)
+        task1.cancel.assert_called_with()
+        task2.cancel.assert_called_with()
+        task3.cancel.assert_called_with()
+        gather_mock.assert_called_with(task1, task2, task3, return_exceptions=True, loop=loop)
         loop.default_exception_handler.assert_called_once_with({
             'message': 'Unhandled exception during shutdown',
             'exception': task3_exception,
-            'task': task3(),
+            'task': task3,
         })
         logger_mock.debug.assert_called_once_with(
             'Cancelling outstanding tasks',

--- a/tests/asyncio_helper_test.py
+++ b/tests/asyncio_helper_test.py
@@ -1,16 +1,18 @@
 import asyncio
 import signal
 from asyncio import Event
-from unittest.mock import ANY, Mock
+from typing import AbstractSet, Optional, Callable, Any
+from unittest.mock import ANY, Mock, sentinel
 
 import pytest
+from pytest_mock import MockFixture
 
 from galts_trade_api.asyncio_helper import AsyncProgramEnv, run_program_forever, shutdown, \
     signal_handler
 from .utils import AsyncMock
 
 
-def test_signal_handler_log_and_shutdown(mocker):
+def test_signal_handler_log_and_shutdown(mocker: MockFixture):
     logger_mock = mocker.patch('galts_trade_api.asyncio_helper.logger')
     shutdown_mock = mocker.patch('galts_trade_api.asyncio_helper.shutdown')
     loop = Mock(spec_set=asyncio.AbstractEventLoop)
@@ -28,7 +30,7 @@ def test_signal_handler_log_and_shutdown(mocker):
 
 class TestShutdown:
     @pytest.mark.asyncio
-    async def test_log_and_stop_loop(self, mocker):
+    async def test_log_and_stop_loop(self, mocker: MockFixture):
         logger_mock = mocker.patch('galts_trade_api.asyncio_helper.logger')
         loop = Mock(spec_set=asyncio.AbstractEventLoop)
 
@@ -43,7 +45,7 @@ class TestShutdown:
         )
 
     @pytest.mark.asyncio
-    async def test_cancel_tasks(self, mocker):
+    async def test_cancel_tasks(self, mocker: MockFixture):
         logger_mock = mocker.patch('galts_trade_api.asyncio_helper.logger')
         loop = Mock(spec_set=asyncio.AbstractEventLoop)
         current_task_mock = mocker.patch('asyncio.current_task', autospec=True)
@@ -87,12 +89,19 @@ def fixture_setup_loop_by_arguments():
 
 class TestRunProgramForever:
     @pytest.mark.parametrize('loop_debug, handle_signals', fixture_setup_loop_by_arguments())
-    def test_setup_loop_by_arguments(self, mocker, loop_debug, handle_signals):
+    def test_setup_loop_by_arguments(
+        self,
+        mocker: MockFixture,
+        loop_debug: bool,
+        handle_signals: AbstractSet[signal.Signals]
+    ):
         logger_mock = mocker.patch('galts_trade_api.asyncio_helper.logger')
         env_mock = mocker.patch('galts_trade_api.asyncio_helper.AsyncProgramEnv')
         loop = Mock(spec_set=asyncio.AbstractEventLoop)
 
-        def program(env): assert env is env_mock()
+        def program(env) -> object:
+            assert env is env_mock()
+            return sentinel.a_program_result
 
         run_program_forever(program, loop, loop_debug, handle_signals)
 
@@ -102,11 +111,11 @@ class TestRunProgramForever:
             loop.add_signal_handler.assert_any_call(sig, ANY)
 
         loop.set_exception_handler.assert_called_once_with(env_mock().exception_handler)
-        loop.create_task.assert_called_once_with(program(env_mock()))
+        loop.create_task.assert_called_once_with(sentinel.a_program_result)
         loop.run_forever.assert_called_once_with()
         logger_mock.info.assert_called_once_with('Successfully shutdown', process_id=ANY)
 
-    def test_setup_loop_by_defaults(self, mocker):
+    def test_setup_loop_by_defaults(self, mocker: MockFixture):
         mocker.patch('galts_trade_api.asyncio_helper.AsyncProgramEnv')
         new_event_loop_mock = mocker.patch('asyncio.new_event_loop', autospec=True)
 
@@ -139,7 +148,7 @@ class TestAsyncProgramEnv:
         assert env.exception_handler_patch is None
 
     @pytest.mark.parametrize('value', fixture_exception_handler_patch_success())
-    def test_exception_handler_patch_success(self, value):
+    def test_exception_handler_patch_success(self, value: Optional[Callable]):
         env = AsyncProgramEnv()
 
         env.exception_handler_patch = value
@@ -147,14 +156,14 @@ class TestAsyncProgramEnv:
         assert env.exception_handler_patch is value
 
     @pytest.mark.parametrize('value', fixture_exception_handler_patch_exception_for_wrong_type())
-    def test_exception_handler_patch_exception_for_wrong_type(self, value):
+    def test_exception_handler_patch_exception_for_wrong_type(self, value: Any):
         env = AsyncProgramEnv()
 
         with pytest.raises(TypeError, match='should be a callable or None'):
             env.exception_handler_patch = value
 
     @pytest.mark.asyncio
-    async def test_exception_handler_log_and_shutdown(self, mocker):
+    async def test_exception_handler_log_and_shutdown(self, mocker: MockFixture):
         logger_mock = mocker.patch('galts_trade_api.asyncio_helper.logger')
         shutdown_mock = mocker.patch(
             'galts_trade_api.asyncio_helper.shutdown',
@@ -173,7 +182,7 @@ class TestAsyncProgramEnv:
         logger_mock.info.assert_called_once_with('Caught exception', process_id=ANY)
 
     @pytest.mark.asyncio
-    async def test_exception_handler_call_patch(self, mocker):
+    async def test_exception_handler_call_patch(self, mocker: MockFixture):
         mocker.patch('galts_trade_api.asyncio_helper.shutdown')
         is_called = Event()
 

--- a/tests/asyncio_helper_test.py
+++ b/tests/asyncio_helper_test.py
@@ -1,11 +1,58 @@
 import asyncio
+import signal
 from asyncio import Event
 from unittest.mock import ANY, Mock
 
 import pytest
 
-from galts_trade_api.asyncio_helper import AsyncProgramEnv
+from galts_trade_api.asyncio_helper import AsyncProgramEnv, run_program_forever
 from .utils import AsyncMock
+
+
+def fixture_setup_loop_by_arguments():
+    yield True, [signal.SIGTERM]
+    yield False, [signal.SIGABRT]
+
+
+class TestRunProgramForever:
+    @pytest.mark.parametrize(
+        'loop_debug, handle_signals',
+        fixture_setup_loop_by_arguments()
+    )
+    def test_setup_loop_by_arguments(self, mocker, loop_debug, handle_signals):
+        logger_mock = mocker.patch('galts_trade_api.asyncio_helper.logger')
+        env_mock = mocker.patch('galts_trade_api.asyncio_helper.AsyncProgramEnv')
+        loop = Mock(spec_set=asyncio.AbstractEventLoop)
+
+        def program(env):
+            assert env is env_mock()
+
+        run_program_forever(program, loop, loop_debug, handle_signals)
+
+        loop.set_debug.assert_called_once_with(loop_debug)
+
+        for sig in handle_signals:
+            loop.add_signal_handler.assert_any_call(sig, ANY)
+
+        loop.set_exception_handler.assert_called_once_with(env_mock().exception_handler)
+        loop.create_task.assert_called_once_with(program(env_mock()))
+        loop.run_forever.assert_called_once_with()
+
+        logger_mock.info.assert_called_once_with('Successfully shutdown', process_id=ANY)
+
+    def test_setup_loop_by_defaults(self, mocker):
+        env_mock = mocker.patch('galts_trade_api.asyncio_helper.AsyncProgramEnv')
+        new_event_loop_mock = mocker.patch('asyncio.new_event_loop', autospec=True)
+
+        run_program_forever(lambda e: None)
+
+        loop = new_event_loop_mock()
+        loop.set_debug.assert_not_called()
+        loop.add_signal_handler.assert_any_call(signal.SIGTERM, ANY)
+        loop.add_signal_handler.assert_any_call(signal.SIGINT, ANY)
+
+        loop.run_until_complete.assert_called_once_with(loop.shutdown_asyncgens())
+        loop.close.assert_called_once_with()
 
 
 def fixture_exception_handler_patch_success():

--- a/tests/asyncio_helper_test.py
+++ b/tests/asyncio_helper_test.py
@@ -95,8 +95,7 @@ class TestRunProgramForever:
         env_mock = mocker.patch('galts_trade_api.asyncio_helper.AsyncProgramEnv')
         loop = Mock(spec_set=asyncio.AbstractEventLoop)
 
-        def program(env):
-            assert env is env_mock()
+        def program(env): assert env is env_mock()
 
         run_program_forever(program, loop, loop_debug, handle_signals)
 

--- a/tests/exchange_test.py
+++ b/tests/exchange_test.py
@@ -1,0 +1,99 @@
+import datetime
+from typing import Optional
+
+import pytest
+
+from galts_trade_api.exchange import Exchange, Market
+
+
+def fixture_exchange_constructor_cast_properties():
+    # String properties
+    for prop in ('tag', 'name',):
+        yield prop, 1, '1'
+        yield prop, 2.0, '2.0'
+        yield prop, False, 'False'
+        yield prop, ' test ', 'test'
+
+    # Integer properties
+    for prop in ('id',):
+        yield prop, '-1', -1
+        yield prop, '1', 1
+        yield prop, 2.0, 2
+
+
+class TestExchange:
+    @pytest.mark.parametrize(
+        'prop, arg_value, expected_value',
+        fixture_exchange_constructor_cast_properties()
+    )
+    def test_constructor_cast_properties(self, prop: str, arg_value, expected_value):
+        instance = self._factory_exchange(**{prop: arg_value})
+
+        assert getattr(instance, prop) == expected_value
+
+    def test_add_market_exception_on_duplicate(self):
+        exchange = self._factory_exchange()
+        market = factory_market()
+        exchange.add_market(market)
+
+        with pytest.raises(ValueError, match='already exists'):
+            exchange.add_market(market)
+
+    def test_get_market_by_custom_tag(self):
+        market_tag = 'market-tag'
+        exchange = self._factory_exchange()
+        market = factory_market(custom_tag=market_tag)
+
+        exchange.add_market(market)
+
+        assert exchange.get_market_by_custom_tag(market_tag) is market
+
+    @classmethod
+    def _factory_exchange(
+        cls,
+        id: Optional[int] = 1,
+        tag: Optional[str] = 'tag',
+        name: Optional[str] = 'name',
+        create_time: Optional[datetime.datetime] = datetime.datetime.now(),
+        delete_time: Optional[datetime.datetime] = datetime.datetime.now(),
+        disable_time: Optional[datetime.datetime] = datetime.datetime.now(),
+    ) -> Exchange:
+        return Exchange(id, tag, name, create_time, delete_time, disable_time)
+
+
+def fixture_market_constructor_cast_properties():
+    # String properties
+    for prop in ('custom_tag', 'trade_endpoint',):
+        yield prop, 1, '1'
+        yield prop, 2.0, '2.0'
+        yield prop, False, 'False'
+        yield prop, ' test ', 'test'
+
+    # Integer properties
+    for prop in ('id', 'exchange_id', 'symbol_id',):
+        yield prop, '-1', -1
+        yield prop, '1', 1
+        yield prop, 2.0, 2
+
+
+class TestMarket:
+    @pytest.mark.parametrize(
+        'prop, arg_value, expected_value',
+        fixture_market_constructor_cast_properties()
+    )
+    def test_constructor_cast_properties(self, prop: str, arg_value, expected_value):
+        instance = factory_market(**{prop: arg_value})
+
+        assert getattr(instance, prop) == expected_value
+
+
+def factory_market(
+    id: Optional[int] = 1,
+    custom_tag: Optional[str] = 'tag',
+    exchange_id: Optional[int] = 3,
+    symbol_id: Optional[int] = 4,
+    trade_endpoint: Optional[str] = 'test.local',
+    create_time: Optional[datetime.datetime] = datetime.datetime.now(),
+    delete_time: Optional[datetime.datetime] = datetime.datetime.now(),
+) -> Market:
+    return Market(id, custom_tag, exchange_id, symbol_id, trade_endpoint, create_time, delete_time)

--- a/tests/exchange_test.py
+++ b/tests/exchange_test.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -31,7 +31,7 @@ class TestExchange:
         'prop, arg_value, expected_value',
         fixture_exchange_constructor_cast_properties()
     )
-    def test_constructor_cast_properties(self, prop: str, arg_value, expected_value):
+    def test_constructor_cast_properties(self, prop: str, arg_value: Any, expected_value: Any):
         instance = self._factory_exchange(**{prop: arg_value})
 
         assert getattr(instance, prop) == expected_value
@@ -91,7 +91,7 @@ class TestMarket:
         'prop, arg_value, expected_value',
         fixture_market_constructor_cast_properties()
     )
-    def test_constructor_cast_properties(self, prop: str, arg_value, expected_value):
+    def test_constructor_cast_properties(self, prop: str, arg_value: Any, expected_value: Any):
         instance = factory_market(**{prop: arg_value})
 
         assert getattr(instance, prop) == expected_value

--- a/tests/exchange_test.py
+++ b/tests/exchange_test.py
@@ -20,6 +20,11 @@ def fixture_exchange_constructor_cast_properties():
         yield prop, '1', 1
         yield prop, 2.0, 2
 
+    # Time properties
+    for prop in ('create_time', 'delete_time', 'disable_time',):
+        now = datetime.datetime.now()
+        yield prop, now, now
+
 
 class TestExchange:
     @pytest.mark.parametrize(
@@ -74,6 +79,11 @@ def fixture_market_constructor_cast_properties():
         yield prop, '-1', -1
         yield prop, '1', 1
         yield prop, 2.0, 2
+
+    # Time properties
+    for prop in ('create_time', 'delete_time',):
+        now = datetime.datetime.now()
+        yield prop, now, now
 
 
 class TestMarket:

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -66,7 +66,7 @@ def fixture_init_exchange_entities_exception_on_data_inconsistency():
                 'delete_time': None,
             },
             2: {
-                'id': 1,
+                'id': 2,
                 'tag': 'asset-b',
                 'name': 'Asset B',
                 'precision': 2,

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -1,0 +1,283 @@
+import asyncio
+from typing import Awaitable, Callable, List, Mapping, Optional, Sequence
+from unittest.mock import ANY, Mock, call, patch
+
+import pytest
+
+from galts_trade_api.terminal import Terminal
+from galts_trade_api.transport import DepthConsumeKey, MessageConsumerCollection, TransportFactory
+from .utils import AsyncMock
+
+
+def fixture_init_transport_calls_factory():
+    yield None
+    yield True
+    yield False
+
+
+def fixture_init_exchange_entities_exception_for_missed_key():
+    yield {}, 'exchanges'
+    yield {'exchanges': {}}, 'markets'
+    yield {'exchanges': {}, 'markets': {}}, 'symbols'
+    yield {'exchanges': {}, 'markets': {}, 'symbols': {}}, 'assets'
+
+
+def fixture_init_exchange_entities_exception_on_data_inconsistency():
+    empty_data = {'exchanges': {}, 'markets': {}, 'symbols': {}, 'assets': {}}
+    stub_record = {'tag': 'foo', 'delete_time': None}
+
+    yield {**empty_data, 'assets': {1: stub_record, 2: stub_record}}, \
+        'Assets with duplicates in tags found: foo'
+
+    yield {**empty_data, 'exchanges': {1: stub_record, 2: stub_record}}, \
+        'Exchanges with duplicates in tags found: foo'
+
+    yield {
+        **empty_data,
+        'exchanges': {
+            1: {
+                'id': 1,
+                'tag': 'exchange',
+                'name': 'Exchange',
+                'create_time': None,
+                'delete_time': None,
+                'disable_time': None,
+            },
+        },
+        'markets': {
+            1: {
+                'id': 1,
+                'exchange_id': 2,
+                'delete_time': None,
+            },
+        },
+    }, 'No exchange with id 2 has been found for market with id 1'
+
+
+def fixture_init_exchange_entities_ignore_deleted_entities():
+    empty_data = {'exchanges': {}, 'markets': {}, 'symbols': {}, 'assets': {}}
+
+    asset = {
+        'id': 1,
+        'tag': 'asset-a',
+        'name': 'Asset A',
+        'precision': 2,
+        'create_time': None,
+        'delete_time': None,
+    }
+
+    yield 'Asset', {
+        **empty_data,
+        'assets': {
+            1: asset,
+            2: {**asset, **{'id': 2, 'delete_time': True}},
+        },
+    }, call(**asset)
+
+    symbol = {
+        'id': 1,
+        'base_asset_id': 3,
+        'quote_asset_id': 4,
+        'create_time': None,
+        'delete_time': None,
+    }
+
+    yield 'Symbol', {
+        **empty_data,
+        'symbols': {
+            1: symbol,
+            2: {**symbol, **{'id': 2, 'delete_time': True}},
+        },
+    }, call(**symbol)
+
+    exchange = {
+        'id': 1,
+        'tag': 'exchange-a',
+        'name': 'Exchange A',
+        'create_time': None,
+        'delete_time': None,
+        'disable_time': None,
+    }
+
+    yield 'Exchange', {
+        **empty_data,
+        'exchanges': {
+            1: exchange,
+            2: {**exchange, **{'id': 2, 'delete_time': True}},
+        },
+    }, call(**exchange)
+
+    market = {
+        'id': 1,
+        'custom_tag': 'tag-a',
+        'exchange_id': 5,
+        'symbol_id': 6,
+        'trade_endpoint': 'test.local',
+        'create_time': None,
+        'delete_time': None,
+    }
+
+    yield 'Market', {
+        **empty_data,
+        'exchanges': {
+            5: {
+                'id': 5,
+                'tag': 'exchange-a',
+                'name': 'Exchange A',
+                'create_time': None,
+                'delete_time': None,
+                'disable_time': None,
+            },
+        },
+        'markets': {
+            1: market,
+            2: {**market, **{'id': 2, 'delete_time': True}},
+        },
+    }, call(**market)
+
+
+class TestTerminal:
+    def test_transport_factory_property(self):
+        factory1 = Mock(spec_set=TransportFactory)
+        factory2 = Mock(spec_set=TransportFactory)
+
+        terminal = Terminal(factory1)
+        assert terminal.transport_factory is factory1
+        terminal.transport_factory = factory2
+        assert terminal.transport_factory is factory2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('loop_debug', fixture_init_transport_calls_factory())
+    async def test_init_transport_calls_factory(self, loop_debug):
+        factory = AsyncMock(spec_set=TransportFactory)
+        terminal = Terminal(factory)
+        await terminal.init_transport(loop_debug)
+
+        factory.init.assert_called_once_with(loop_debug)
+
+    def test_shutdown_transport_calls_factory(self):
+        factory = Mock(spec_set=TransportFactory)
+        terminal = Terminal(factory)
+        terminal.shutdown_transport()
+
+        factory.shutdown.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    @pytest.mark.skip('SUT have no realization')
+    async def test_auth_user(self):
+        pass
+
+    def test_is_exchange_entities_inited_after_instantiation(self):
+        factory = Mock(spec_set=TransportFactory)
+        terminal = Terminal(factory)
+
+        assert not terminal.is_exchange_entities_inited()
+
+    @pytest.mark.asyncio
+    async def test_wait_exchange_entities_inited_exception_after_timeout(self):
+        factory = Mock(spec_set=TransportFactory)
+        terminal = Terminal(factory)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await terminal.wait_exchange_entities_inited(0.001)
+
+    @pytest.mark.asyncio
+    async def test_init_exchange_entities_calls_factory(self):
+        factory = AsyncMock(spec_set=TransportFactory)
+        terminal = Terminal(factory)
+        await terminal.init_exchange_entities()
+
+        factory.get_exchange_entities.assert_called_once_with(ANY)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'data, expected_key_name',
+        fixture_init_exchange_entities_exception_for_missed_key()
+    )
+    async def test_init_exchange_entities_exception_for_missed_key(
+        self,
+        data: Mapping,
+        expected_key_name: str
+    ):
+        factory_fake = FakeTransportFactory()
+        factory_fake.init_exchange_entities_data = data
+
+        terminal = Terminal(factory_fake)
+        with pytest.raises(KeyError, match=f'Key "{expected_key_name}" is required'):
+            await terminal.init_exchange_entities()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'data, expected_message',
+        fixture_init_exchange_entities_exception_on_data_inconsistency()
+    )
+    async def test_init_exchange_entities_exception_on_data_inconsistency(
+        self,
+        data: Mapping,
+        expected_message: str
+    ):
+        factory_fake = FakeTransportFactory()
+        factory_fake.init_exchange_entities_data = data
+
+        terminal = Terminal(factory_fake)
+        with pytest.raises(ValueError, match=expected_message):
+            await terminal.init_exchange_entities()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'entity_class_name, data, expected_call',
+        fixture_init_exchange_entities_ignore_deleted_entities()
+    )
+    async def test_init_exchange_entities_ignore_deleted_entities(
+        self,
+        mocker,
+        entity_class_name: str,
+        data: Mapping,
+        expected_call: Sequence,
+    ):
+        entity_class_mock = mocker.patch(
+            f'galts_trade_api.terminal.{entity_class_name}',
+            autospec=True
+        )
+
+        factory_fake = FakeTransportFactory()
+        factory_fake.init_exchange_entities_data = data
+
+        terminal = Terminal(factory_fake)
+        await terminal.init_exchange_entities()
+
+        assert entity_class_mock.call_args == expected_call
+
+    @pytest.mark.asyncio
+    async def test_init_exchange_entities_set_event(self):
+        data = {'exchanges': {}, 'markets': {}, 'symbols': {}, 'assets': {}}
+        factory_fake = FakeTransportFactory()
+        factory_fake.init_exchange_entities_data = data
+
+        terminal = Terminal(factory_fake)
+        await terminal.init_exchange_entities()
+
+        assert terminal.is_exchange_entities_inited()
+        await terminal.wait_exchange_entities_inited(0.001)
+
+
+class FakeTransportFactory(TransportFactory):
+    def __init__(self):
+        self.init_exchange_entities_data: Optional[Mapping] = None
+
+    async def get_exchange_entities(
+        self,
+        on_response: Callable[..., Awaitable]
+    ) -> MessageConsumerCollection:
+        result = MessageConsumerCollection()
+        result.add_consumer(on_response)
+        await result.send(self.init_exchange_entities_data)
+
+        return result
+
+    async def consume_price_depth(
+        self,
+        on_response: Callable[..., Awaitable],
+        consume_keys: Optional[List[DepthConsumeKey]] = None
+    ) -> MessageConsumerCollection:
+        pass

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -1,4 +1,5 @@
 import asyncio
+from asyncio import Event
 from typing import Awaitable, Callable, List, Mapping, Optional, Sequence
 from unittest.mock import ANY, Mock, call
 
@@ -425,15 +426,19 @@ class TestTerminal:
 
     @pytest.mark.asyncio
     async def test_subscribe_to_prices(self):
+        is_called = Event()
         data = ('foo', {'bar': 100500})
         factory_fake = FakeTransportFactory()
         factory_fake.consume_price_depth_data = data
 
-        async def cb(*args): assert args == data
+        async def cb(*args):
+            assert args == data
+            is_called.set()
 
         terminal = Terminal(factory_fake)
         keys = []
         await terminal.subscribe_to_prices(cb, keys)
+        assert is_called.is_set()
 
 
 class FakeTransportFactory(TransportFactory):

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -429,8 +429,7 @@ class TestTerminal:
         factory_fake = FakeTransportFactory()
         factory_fake.consume_price_depth_data = data
 
-        async def cb(*args):
-            assert args == data
+        async def cb(*args): assert args == data
 
         terminal = Terminal(factory_fake)
         keys = []

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -1,6 +1,6 @@
 import asyncio
 from typing import Awaitable, Callable, List, Mapping, Optional, Sequence
-from unittest.mock import ANY, Mock, call, patch
+from unittest.mock import ANY, Mock, call
 
 import pytest
 
@@ -34,11 +34,63 @@ def fixture_init_exchange_entities_exception_on_data_inconsistency():
 
     yield {
         **empty_data,
+        'assets': {
+            1: {
+                'id': 1,
+                'tag': 'asset-a',
+                'name': 'Asset A',
+                'precision': 2,
+                'create_time': None,
+                'delete_time': None,
+            },
+        },
+        'symbols': {
+            1: {
+                'id': 1,
+                'base_asset_id': 2,
+                'quote_asset_id': 3,
+                'delete_time': None,
+            },
+        },
+    }, 'No base asset with id 2 has been found for symbol with id 1'
+
+    yield {
+        **empty_data,
+        'assets': {
+            1: {
+                'id': 1,
+                'tag': 'asset-a',
+                'name': 'Asset A',
+                'precision': 2,
+                'create_time': None,
+                'delete_time': None,
+            },
+            2: {
+                'id': 1,
+                'tag': 'asset-b',
+                'name': 'Asset B',
+                'precision': 2,
+                'create_time': None,
+                'delete_time': None,
+            },
+        },
+        'symbols': {
+            1: {
+                'id': 1,
+                'base_asset_id': 2,
+                'quote_asset_id': 3,
+                'delete_time': None,
+            },
+        },
+    }, 'No quote asset with id 3 has been found for symbol with id 1'
+
+    yield {
+        **empty_data,
         'exchanges': {
             1: {
                 'id': 1,
-                'tag': 'exchange',
-                'name': 'Exchange',
+                'tag': 'exchange-a',
+                'name': 'Exchange A',
                 'create_time': None,
                 'delete_time': None,
                 'disable_time': None,
@@ -48,10 +100,41 @@ def fixture_init_exchange_entities_exception_on_data_inconsistency():
             1: {
                 'id': 1,
                 'exchange_id': 2,
+                'symbol_id': 6,
                 'delete_time': None,
             },
         },
     }, 'No exchange with id 2 has been found for market with id 1'
+
+    yield {
+        **empty_data,
+        'exchanges': {
+            1: {
+                'id': 1,
+                'tag': 'exchange-a',
+                'name': 'Exchange A',
+                'create_time': None,
+                'delete_time': None,
+                'disable_time': None,
+            },
+            2: {
+                'id': 2,
+                'tag': 'exchange-b',
+                'name': 'Exchange B',
+                'create_time': None,
+                'delete_time': None,
+                'disable_time': None,
+            },
+        },
+        'markets': {
+            1: {
+                'id': 1,
+                'exchange_id': 2,
+                'symbol_id': 6,
+                'delete_time': None,
+            },
+        },
+    }, 'No symbol with id 6 has been found for market with id 1'
 
 
 def fixture_init_exchange_entities_ignore_deleted_entities():
@@ -84,6 +167,24 @@ def fixture_init_exchange_entities_ignore_deleted_entities():
 
     yield 'Symbol', {
         **empty_data,
+        'assets': {
+            3: {
+                'id': 3,
+                'tag': 'asset-a',
+                'name': 'Asset A',
+                'precision': 2,
+                'create_time': None,
+                'delete_time': None,
+            },
+            4: {
+                'id': 4,
+                'tag': 'asset-b',
+                'name': 'Asset B',
+                'precision': 2,
+                'create_time': None,
+                'delete_time': None,
+            },
+        },
         'symbols': {
             1: symbol,
             2: {**symbol, **{'id': 2, 'delete_time': True}},
@@ -119,6 +220,33 @@ def fixture_init_exchange_entities_ignore_deleted_entities():
 
     yield 'Market', {
         **empty_data,
+        'assets': {
+            3: {
+                'id': 3,
+                'tag': 'asset-a',
+                'name': 'Asset A',
+                'precision': 2,
+                'create_time': None,
+                'delete_time': None,
+            },
+            4: {
+                'id': 4,
+                'tag': 'asset-b',
+                'name': 'Asset B',
+                'precision': 2,
+                'create_time': None,
+                'delete_time': None,
+            },
+        },
+        'symbols': {
+            6: {
+                'id': 6,
+                'base_asset_id': 3,
+                'quote_asset_id': 4,
+                'create_time': None,
+                'delete_time': None,
+            },
+        },
         'exchanges': {
             5: {
                 'id': 5,

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -4,6 +4,7 @@ from typing import Awaitable, Callable, List, Mapping, Optional, Sequence
 from unittest.mock import ANY, Mock, call
 
 import pytest
+from pytest_mock import MockFixture
 
 from galts_trade_api.terminal import Terminal
 from galts_trade_api.transport import DepthConsumeKey, MessageConsumerCollection, TransportFactory
@@ -277,7 +278,7 @@ class TestTerminal:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('loop_debug', fixture_init_transport_calls_factory())
-    async def test_init_transport_calls_factory(self, loop_debug):
+    async def test_init_transport_calls_factory(self, loop_debug: bool):
         factory = AsyncMock(spec_set=TransportFactory)
         terminal = Terminal(factory)
         await terminal.init_transport(loop_debug)
@@ -359,7 +360,7 @@ class TestTerminal:
     )
     async def test_init_exchange_entities_ignore_deleted_entities(
         self,
-        mocker,
+        mocker: MockFixture,
         entity_class_name: str,
         data: Mapping,
         expected_call: Sequence,

--- a/tests/tools_test.py
+++ b/tests/tools_test.py
@@ -1,0 +1,41 @@
+import pytest
+
+from galts_trade_api.tools import Singleton
+
+
+def fixture_foo():
+    class Foo(metaclass=Singleton):
+        pass
+
+    yield Foo(), Foo(), True
+
+    class Bar(
+        metaclass=Singleton,
+        singleton_hash_args=[0],
+        singleton_hash_kwargs=['baz']
+    ):
+        def __init__(self, foo, bar, baz='str'):
+            self._foo = foo
+            self._bar = bar
+            self._baz = baz
+
+    inst1 = Bar('foo_value1', 'bar_value1', baz='baz_value1')
+    inst2 = Bar('foo_value1', 'bar_value2', baz='baz_value1')
+    inst3 = Bar('foo_value2', 'bar_value3', baz='baz_value1')
+    inst4 = Bar('foo_value1', 'bar_value4', baz='baz_value2')
+    inst5 = Bar('foo_value2', 'bar_value5', baz='baz_value2')
+
+    yield inst1, inst2, True
+    yield inst1, inst3, False
+    yield inst1, inst4, False
+    yield inst1, inst5, False
+
+
+class TestSingleton:
+    @staticmethod
+    @pytest.mark.parametrize('inst1, inst2, should_be_same', fixture_foo())
+    def test_instances_same(inst1, inst2, should_be_same):
+        if should_be_same:
+            assert inst1 is inst2
+        else:
+            assert inst1 is not inst2

--- a/tests/tools_test.py
+++ b/tests/tools_test.py
@@ -34,7 +34,7 @@ def fixture_foo():
 class TestSingleton:
     @staticmethod
     @pytest.mark.parametrize('inst1, inst2, should_be_same', fixture_foo())
-    def test_instances_same(inst1, inst2, should_be_same):
+    def test_instances_same(inst1: object, inst2: object, should_be_same: bool):
         if should_be_same:
             assert inst1 is inst2
         else:

--- a/tests/transport/exchange_info_client_test.py
+++ b/tests/transport/exchange_info_client_test.py
@@ -192,8 +192,7 @@ class TestSymbolClient:
     ):
         client = ExchangeInfoClient(grpc_channel, timeout_get_entities=1)
 
-        def sut() -> None:
-            client.get_entities(*method_inputs)
+        def sut() -> None: client.get_entities(*method_inputs)
 
         with pytest.raises(grpc.RpcError) as exc_info:
             with thread_with_timeout(sut):

--- a/tests/transport/exchange_info_client_test.py
+++ b/tests/transport/exchange_info_client_test.py
@@ -1,0 +1,218 @@
+import uuid
+from datetime import datetime
+from typing import Dict, Tuple, Type
+from unittest import mock
+from unittest.mock import call
+
+import grpc
+import grpc_testing
+import pytest
+from google.protobuf.pyext._message import MethodDescriptor
+
+import galts_trade_api.transport.protos.exchange_info.api_pb2 as exchange_info_api
+from galts_trade_api.transport.exchange_info_client import ExchangeInfoClient
+from galts_trade_api.transport.grpc_utils import message_to_dict
+from tests.utils import fixture_grpc_error_status_codes, thread_with_timeout
+
+
+@pytest.fixture(scope='module')
+def grpc_channel():
+    descriptors = [exchange_info_api.DESCRIPTOR.services_by_name['ExchangeInfoApi']]
+    return grpc_testing.channel(descriptors, grpc_testing.strict_real_time())
+
+
+def fixture_incorrect_factory_dsn():
+    exception_text = 'Parameter is not specified: dsn'
+
+    yield '', ValueError, exception_text
+    yield None, ValueError, exception_text
+    yield 123, AttributeError, None
+
+
+def fixture_get_entities():
+    some_datetime = datetime(2019, 7, 17, 17, 34, 22, 436922)
+
+    request_expected = exchange_info_api.EntityKinds()
+    request_expected.entity_kinds.extend(
+        [
+            exchange_info_api.ASSET,
+            exchange_info_api.SYMBOL,
+            exchange_info_api.MARKET,
+            exchange_info_api.EXCHANGE
+        ]
+    )
+
+    response = exchange_info_api.Entities()
+    for entity in request_expected.entity_kinds:
+        if entity == exchange_info_api.ASSET:
+            response.assets[1].id = 1
+            response.assets[1].tag = 'BTC'
+            response.assets[1].create_time.FromDatetime(some_datetime)
+            response.assets[1].delete_time.FromDatetime(some_datetime)
+            response.assets[1].name = 'BTC'
+            response.assets[1].precision = 8
+
+        if entity == exchange_info_api.SYMBOL:
+            response.symbols[1].id = 1
+            response.symbols[1].create_time.FromDatetime(some_datetime)
+            response.symbols[1].delete_time.FromDatetime(some_datetime)
+            response.symbols[1].base_asset_id = 1
+            response.symbols[1].quote_asset_id = 2
+
+        if entity == exchange_info_api.MARKET:
+            response.markets[1].id = 1
+            response.markets[1].custom_tag = 'BTCUSD'
+            response.markets[1].create_time.FromDatetime(some_datetime)
+            response.markets[1].delete_time.FromDatetime(some_datetime)
+            response.markets[1].symbol_id = 1
+            response.markets[1].exchange_id = 1
+            response.markets[1].trade_endpoint = 'trade_endpoint'
+
+        if entity == exchange_info_api.EXCHANGE:
+            response.exchanges[1].id = 1
+            response.exchanges[1].tag = 'binance'
+            response.exchanges[1].create_time.FromDatetime(some_datetime)
+            response.exchanges[1].delete_time.FromDatetime(some_datetime)
+            response.exchanges[1].name = 'binance'
+            response.exchanges[1].disable_time.FromDatetime(some_datetime)
+
+    result_expected = message_to_dict(response)
+
+    request_id = uuid.uuid4().hex
+
+    method_inputs = (request_id,)
+
+    yield method_inputs, request_expected, response, result_expected, request_id
+
+
+def fixture_get_entities_failed():
+    request_expected = exchange_info_api.EntityKinds()
+    request_expected.entity_kinds.extend(
+        [
+            exchange_info_api.ASSET,
+            exchange_info_api.SYMBOL,
+            exchange_info_api.MARKET,
+            exchange_info_api.EXCHANGE
+        ]
+    )
+    request_id = uuid.uuid4().hex
+    method_inputs = (request_id,)
+
+    yield from fixture_grpc_error_status_codes(method_inputs, request_expected, request_id)
+
+
+class TestSymbolClient:
+    @staticmethod
+    def test_client_init(grpc_channel: grpc_testing.Channel):
+        patch_taget = 'galts_trade_api.transport.exchange_info_client.correct_timeout'
+        with mock.patch(patch_taget) as correct_timeout_mock:
+            correct_timeout_mock.return_value = 1
+
+            client = ExchangeInfoClient(grpc_channel, timeout_get_entities=1)
+
+            assert correct_timeout_mock.mock_calls == [call(1)]
+            assert getattr(client, 'timeout_get_entities') == 1
+
+    @staticmethod
+    def test_factory():
+        patch_taget = 'galts_trade_api.transport.exchange_info_client.correct_timeout'
+        with mock.patch(patch_taget) as correct_timeout_mock:
+            correct_timeout_mock.return_value = 1
+
+            client = ExchangeInfoClient.factory('DSN', timeout_get_entities=1)
+
+            assert correct_timeout_mock.mock_calls == [call(1)]
+            assert getattr(client, 'timeout_get_entities') == 1
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'incorrect_dsn, exception_expected, exception_text',
+        fixture_incorrect_factory_dsn()
+    )
+    def test_incorrect_factory_dsn(
+        incorrect_dsn: str,
+        exception_expected: Type[Exception],
+        exception_text: str
+    ):
+        with pytest.raises(exception_expected, match=exception_text):
+            ExchangeInfoClient.factory(incorrect_dsn)
+
+    @staticmethod
+    def test_destroy():
+        mock_channel = mock.MagicMock(spec_set=grpc.Channel)
+
+        client = ExchangeInfoClient(mock_channel)
+        client.destroy()
+
+        mock_channel.close.assert_called_once()
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'method_inputs, request_expected, response, result_expected, request_id_expected',
+        fixture_get_entities()
+    )
+    def test_get_entities(
+        grpc_channel: grpc_testing.Channel,
+        method_inputs: Tuple,
+        response: exchange_info_api.Entities,
+        request_expected: exchange_info_api.EntityKinds,
+        result_expected: Dict,
+        request_id_expected: str
+    ):
+        client = ExchangeInfoClient(grpc_channel, timeout_get_entities=1)
+
+        result = None
+
+        def sut() -> None:
+            nonlocal result
+            result = client.get_entities(*method_inputs)
+
+        with thread_with_timeout(sut):
+            invocation_metadata, request, channel_rpc = grpc_channel.take_unary_unary(
+                get_method_descriptor('GetEntities')
+            )
+
+            channel_rpc.terminate(response, None, grpc.StatusCode.OK, None)
+
+        assert request == request_expected
+        assert dict(invocation_metadata)['request_id'] == request_id_expected
+        assert result == result_expected
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'status_code_expected, method_inputs, request_expected, request_id_expected',
+        fixture_get_entities_failed()
+    )
+    def test_get_entities_failed(
+        grpc_channel: grpc_testing.Channel,
+        status_code_expected: grpc.StatusCode,
+        method_inputs: Tuple,
+        request_expected: exchange_info_api.EntityKinds,
+        request_id_expected: str
+    ):
+        client = ExchangeInfoClient(grpc_channel, timeout_get_entities=1)
+
+        def sut() -> None:
+            client.get_entities(*method_inputs)
+
+        with pytest.raises(grpc.RpcError) as exc_info:
+            with thread_with_timeout(sut):
+                invocation_metadata, request, channel_rpc = grpc_channel.take_unary_unary(
+                    get_method_descriptor('GetEntities')
+                )
+
+                channel_rpc.terminate(None, None, status_code_expected, None)
+
+        assert exc_info.value.code() == status_code_expected
+        assert request == request_expected
+        assert dict(invocation_metadata)['request_id'] == request_id_expected
+
+
+def get_method_descriptor(method_name: str) -> MethodDescriptor:
+    method_descriptor = exchange_info_api.DESCRIPTOR \
+        .services_by_name['ExchangeInfoApi'] \
+        .methods_by_name[method_name]
+
+    return method_descriptor
+
+# @TODO Catch and fix flanky test fail because of an exception in a thread

--- a/tests/transport/exchange_info_client_test.py
+++ b/tests/transport/exchange_info_client_test.py
@@ -214,5 +214,3 @@ def get_method_descriptor(method_name: str) -> MethodDescriptor:
         .methods_by_name[method_name]
 
     return method_descriptor
-
-# @TODO Catch and fix flanky test fail because of an exception in a thread

--- a/tests/transport/exchange_info_client_test.py
+++ b/tests/transport/exchange_info_client_test.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from typing import Dict, Tuple, Type
+from typing import Any, Dict, Optional, Tuple, Type
 from unittest import mock
 from unittest.mock import call
 
@@ -130,9 +130,9 @@ class TestSymbolClient:
         fixture_incorrect_factory_dsn()
     )
     def test_incorrect_factory_dsn(
-        incorrect_dsn: str,
+        incorrect_dsn: Any,
         exception_expected: Type[Exception],
-        exception_text: str
+        exception_text: Optional[str]
     ):
         with pytest.raises(exception_expected, match=exception_text):
             ExchangeInfoClient.factory(incorrect_dsn)

--- a/tests/transport/exchange_info_client_test.py
+++ b/tests/transport/exchange_info_client_test.py
@@ -104,8 +104,8 @@ def fixture_get_entities_failed():
 class TestSymbolClient:
     @staticmethod
     def test_client_init(grpc_channel: grpc_testing.Channel):
-        patch_taget = 'galts_trade_api.transport.exchange_info_client.correct_timeout'
-        with mock.patch(patch_taget) as correct_timeout_mock:
+        patch_target = 'galts_trade_api.transport.exchange_info_client.correct_timeout'
+        with mock.patch(patch_target) as correct_timeout_mock:
             correct_timeout_mock.return_value = 1
 
             client = ExchangeInfoClient(grpc_channel, timeout_get_entities=1)
@@ -115,8 +115,8 @@ class TestSymbolClient:
 
     @staticmethod
     def test_factory():
-        patch_taget = 'galts_trade_api.transport.exchange_info_client.correct_timeout'
-        with mock.patch(patch_taget) as correct_timeout_mock:
+        patch_target = 'galts_trade_api.transport.exchange_info_client.correct_timeout'
+        with mock.patch(patch_target) as correct_timeout_mock:
             correct_timeout_mock.return_value = 1
 
             client = ExchangeInfoClient.factory('DSN', timeout_get_entities=1)

--- a/tests/transport/grpc_utils_test.py
+++ b/tests/transport/grpc_utils_test.py
@@ -1,0 +1,67 @@
+from typing import Optional
+
+import pytest
+
+from galts_trade_api.transport.grpc_utils import OptionalGrpcTimeout, correct_timeout, \
+    generate_request_id, get_metadata
+
+
+def test_generate_request_id():
+    request_id = generate_request_id()
+
+    assert isinstance(request_id, str)
+    assert len(request_id) == 32
+
+
+def test_get_metadata():
+    request_id = 'c997bf1f855d47078afe6e5ae0b35e89'
+
+    metadata_with_specified_request_id = [('request_id', request_id)]
+
+    assert get_metadata(request_id) == metadata_with_specified_request_id
+    assert get_metadata() != metadata_with_specified_request_id
+
+
+def fixture_correct_timeout():
+    input_timeout1 = None
+    timeout_expected1 = None
+
+    input_timeout2 = -1
+    timeout_expected2 = None
+
+    input_timeout3 = 0
+    timeout_expected3 = None
+
+    input_timeout4 = 1
+    timeout_expected4 = 1.0
+
+    input_timeout5 = ' 00.9900 '
+    timeout_expected5 = 0.99
+
+    yield input_timeout1, timeout_expected1, type(timeout_expected1)
+    yield input_timeout2, timeout_expected2, type(timeout_expected2)
+    yield input_timeout3, timeout_expected3, type(timeout_expected3)
+    yield input_timeout4, timeout_expected4, type(timeout_expected4)
+    yield input_timeout5, timeout_expected5, type(timeout_expected5)
+
+
+@pytest.mark.parametrize(
+    'input_timeout, timeout_expected, type_expected',
+    fixture_correct_timeout()
+)
+def test_correct_timeout(
+    input_timeout: OptionalGrpcTimeout,
+    timeout_expected: Optional[float],
+    type_expected: type
+):
+    result_timeout = correct_timeout(input_timeout)
+
+    assert result_timeout == timeout_expected
+    assert type(result_timeout) == type_expected
+
+
+def test_correct_timeout_failed():
+    incorrect_value = '.............'
+
+    with pytest.raises(ValueError, match='could not convert string to float:'):
+        correct_timeout(incorrect_value)

--- a/tests/transport/init_test.py
+++ b/tests/transport/init_test.py
@@ -158,11 +158,8 @@ class TestPipeResponseRouter:
         router = PipeResponseRouter(parent_conn, poll_delay)
         router_task = asyncio.create_task(router.start())
 
-        async def on_response1(data):
-            consumer1_called.set()
-
-        async def on_response2(data):
-            consumer1_called.set()
+        async def on_response1(data): consumer1_called.set()
+        async def on_response2(data): consumer1_called.set()
 
         consumer_collection = router.prepare_consumers_of_response(pipe_request1)
         consumer_collection.add_consumer(on_response1)
@@ -196,8 +193,7 @@ class TestPipeResponseRouter:
         router = PipeResponseRouter(parent_conn, poll_delay)
         router_task = asyncio.create_task(router.start())
 
-        async def on_response(data):
-            consumer1_called.set()
+        async def on_response(data): consumer1_called.set()
 
         consumer_collection = router.prepare_consumers_of_response(pipe_request_known)
         consumer_collection.add_consumer(on_response)
@@ -254,8 +250,7 @@ class TestPipeResponseRouter:
         router = PipeResponseRouter(parent_conn, poll_delay)
         router_task = asyncio.create_task(router.start())
 
-        async def on_response(data):
-            raise expected_exception
+        async def on_response(data): raise expected_exception
 
         consumer_collection = router.prepare_consumers_of_response(pipe_request)
         consumer_collection.add_consumer(on_response)

--- a/tests/transport/init_test.py
+++ b/tests/transport/init_test.py
@@ -1,0 +1,282 @@
+import asyncio
+from asyncio import Event
+from dataclasses import dataclass
+from multiprocessing.connection import Pipe
+from typing import Any, Callable, Optional, Type
+
+import pytest
+
+from galts_trade_api.transport import DepthConsumeKey, MessageConsumerCollection, PipeRequest, \
+    PipeResponseRouter
+
+
+def fixture_format_for_rabbitmq_correct():
+    yield 'a.b.c', ['a', 'b', 'c'], {}
+    yield 'a.b.*', ['a', 'b'], {}
+    yield 'a.*.*', ['a'], {}
+
+    yield 'a.*.*', [], {'exchange': 'a'}
+    yield '*.b.*', [], {'market_tag': 'b'}
+    yield '*.*.c', [], {'symbol_tag': 'c'}
+
+    yield '#', ['*', '*', '*'], {}
+    yield '#', [], {'exchange': '*', 'market_tag': '*', 'symbol_tag': '*'}
+
+
+def fixture_format_for_rabbitmq_wrong():
+    yield '', 'b', 'c', 'Field exchange'
+    yield 'a', '', 'c', 'Field market_tag'
+    yield 'a', 'b', '', 'Field symbol_tag'
+    yield '', '', '', 'Field exchange'
+
+
+class TestDepthConsumeKey:
+    @staticmethod
+    @pytest.mark.parametrize('expected_result, args, kwargs', fixture_format_for_rabbitmq_correct())
+    def test_format_for_rabbitmq_result_format(expected_result, args, kwargs):
+        key = DepthConsumeKey(*args, **kwargs)
+
+        assert expected_result == key.format_for_rabbitmq()
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        'exchange, market_tag, symbol_tag, expected_msg',
+        fixture_format_for_rabbitmq_wrong()
+    )
+    def test_format_for_rabbitmq_exceptions(exchange, market_tag, symbol_tag, expected_msg):
+        with pytest.raises(ValueError, match=expected_msg):
+            DepthConsumeKey(exchange, market_tag, symbol_tag).format_for_rabbitmq()
+
+
+class TestMessageConsumerCollection:
+    @staticmethod
+    @pytest.mark.asyncio
+    async def test_notify_will_call_multiple_consumers():
+        event1 = Event()
+        event2 = Event()
+        expected_data = 'test'
+
+        async def consumer1(data):
+            nonlocal event1, expected_data
+            assert data == expected_data
+            event1.set()
+
+        async def consumer2(data):
+            nonlocal event2, expected_data
+            assert data == expected_data
+            event2.set()
+
+        collection = MessageConsumerCollection()
+        collection.add_consumer(consumer1)
+        collection.add_consumer(consumer2)
+        await collection.notify(expected_data)
+
+        assert event1.is_set()
+        assert event2.is_set()
+
+
+@dataclass(frozen=True)
+class RequestStub(PipeRequest):
+    arg: str
+
+
+def fixture_start_correct():
+    expected_response = 'test response'
+    request = RequestStub('test')
+
+    yield expected_response, 0.001, request, [request, expected_response]
+    yield expected_response, None, request, [request, expected_response]
+
+
+def fixture_start_exceptions():
+    yield 0, ValueError, 'object with indexing'
+    yield 'a message', ValueError, 'exactly 2 elements'
+    yield [RuntimeError('test')], RuntimeError, 'test'
+
+
+class TestPipeResponseRouter:
+    @staticmethod
+    def _factory_task_done_cb(
+        task_done: Event,
+        task_cancelled: Event,
+        on_exception: Callable,
+        is_exception_expected: bool = False
+    ):
+        def result(t: asyncio.Task):
+            task_done.set()
+
+            if t.cancelled():
+                task_cancelled.set()
+                return
+
+            if t.exception() is not None:
+                on_exception(t.exception())
+                raise t.exception()
+
+            if not is_exception_expected:
+                # Cannot throw exception here because the stack can be not the main task
+                # of a thread, therefore the exception won't be propagated.
+                pytest.fail('The task was supposed to done by explicit cancellation')
+
+        return result
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'expected_response, sleep_after_start, pipe_request, response',
+        fixture_start_correct()
+    )
+    async def test_start_correct(
+        self,
+        expected_response: str,
+        sleep_after_start: Optional[float],
+        pipe_request: PipeRequest,
+        response: Any,
+    ):
+        parent_conn, child_conn = Pipe()
+        router_task_done = Event()
+        router_task_cancelled = Event()
+        consumer_called = Event()
+        poll_delay = 0.001
+
+        def on_exception(local_e: BaseException):
+            pytest.fail(f'Unexpected exception: {local_e}')
+
+        router = PipeResponseRouter(parent_conn, on_exception, poll_delay)
+        router_task = asyncio.create_task(router.start())
+        done_cb = self._factory_task_done_cb(router_task_done, router_task_cancelled, on_exception)
+        router_task.add_done_callback(done_cb)
+
+        # Give the task time to some work like it will be in real usage
+        if sleep_after_start:
+            await asyncio.sleep(sleep_after_start)
+
+        async def on_response(data):
+            consumer_called.set()
+            assert data == expected_response
+
+        consumer_collection = router.init_response_consumer(pipe_request)
+        consumer_collection.add_consumer(on_response)
+
+        child_conn.send(response)
+
+        await asyncio.sleep(poll_delay * 5)
+
+        assert consumer_called.is_set()
+
+        router_task.cancel()
+        await asyncio.wait_for(router_task_cancelled.wait(), 0.1)
+
+    @pytest.mark.asyncio
+    async def test_start_notify_only_appropriate_consumer(self):
+        pipe_request1 = RequestStub('test 1')
+        pipe_request2 = RequestStub('test 2')
+        response = [pipe_request1, 'test response']
+
+        parent_conn, child_conn = Pipe()
+        router_task_done = Event()
+        router_task_cancelled = Event()
+        consumer1_called = Event()
+        consumer2_called = Event()
+        poll_delay = 0.001
+
+        def on_exception(local_e: BaseException):
+            pytest.fail(f'Unexpected exception: {local_e}')
+
+        router = PipeResponseRouter(parent_conn, on_exception, poll_delay)
+        router_task = asyncio.create_task(router.start())
+        done_cb = self._factory_task_done_cb(router_task_done, router_task_cancelled, on_exception)
+        router_task.add_done_callback(done_cb)
+
+        async def on_response1(data):
+            consumer1_called.set()
+
+        async def on_response2(data):
+            consumer1_called.set()
+
+        consumer_collection = router.init_response_consumer(pipe_request1)
+        consumer_collection.add_consumer(on_response1)
+        consumer_collection = router.init_response_consumer(pipe_request2)
+        consumer_collection.add_consumer(on_response2)
+
+        child_conn.send(response)
+
+        await asyncio.sleep(poll_delay * 5)
+
+        assert consumer1_called.is_set()
+        assert not consumer2_called.is_set()
+
+        router_task.cancel()
+        await asyncio.wait_for(router_task_cancelled.wait(), 0.1)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        'response, expected_exception_class, expected_exception_msg',
+        fixture_start_exceptions()
+    )
+    async def test_start_exceptions_in_router_task(
+        self,
+        response: Any,
+        expected_exception_class: Optional[Type[Exception]],
+        expected_exception_msg: Optional[str]
+    ):
+        parent_conn, child_conn = Pipe()
+        router_task_done = Event()
+        router_task_cancelled = Event()
+        poll_delay = 0.001
+        exception = None
+
+        def on_exception(local_e: BaseException):
+            nonlocal exception
+            exception = local_e
+
+        router = PipeResponseRouter(parent_conn, lambda: None, poll_delay)
+        router_task = asyncio.create_task(router.start())
+        done_cb = self._factory_task_done_cb(
+            router_task_done,
+            router_task_cancelled,
+            on_exception,
+            True
+        )
+        router_task.add_done_callback(done_cb)
+
+        child_conn.send(response)
+
+        await asyncio.sleep(poll_delay * 5)
+
+        assert exception.__class__ is expected_exception_class
+        assert expected_exception_msg in str(exception)
+
+        await asyncio.wait_for(router_task_done.wait(), 0.1)
+
+    @pytest.mark.asyncio
+    async def test_start_exceptions_in_consumer_task(self):
+        expected_response = 'test response'
+        pipe_request = RequestStub('test')
+        response = [pipe_request, expected_response]
+        expected_exception = RuntimeError('test exception from consumer coroutine')
+
+        parent_conn, child_conn = Pipe()
+        poll_delay = 0.001
+        exception = None
+
+        def on_exception(local_e: BaseException):
+            nonlocal exception
+            exception = local_e
+
+        router = PipeResponseRouter(parent_conn, on_exception, poll_delay)
+        router_task = asyncio.create_task(router.start())
+
+        async def on_response(data):
+            raise expected_exception
+
+        consumer_collection = router.init_response_consumer(pipe_request)
+        consumer_collection.add_consumer(on_response)
+
+        child_conn.send(response)
+
+        await asyncio.sleep(poll_delay * 5)
+
+        assert exception is expected_exception
+        assert not router_task.cancelled()
+
+        router_task.cancel()

--- a/tests/transport/init_test.py
+++ b/tests/transport/init_test.py
@@ -2,7 +2,7 @@ import asyncio
 from asyncio import Event
 from dataclasses import dataclass
 from multiprocessing.connection import Pipe
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Mapping, Optional, Sequence, Type
 from unittest.mock import Mock
 
 import pytest
@@ -34,7 +34,11 @@ def fixture_format_for_rabbitmq_wrong():
 class TestDepthConsumeKey:
     @staticmethod
     @pytest.mark.parametrize('expected_result, args, kwargs', fixture_format_for_rabbitmq_correct())
-    def test_format_for_rabbitmq_result_format(expected_result, args, kwargs):
+    def test_format_for_rabbitmq_result_format(
+        expected_result: str,
+        args: Sequence,
+        kwargs: Mapping
+    ):
         key = DepthConsumeKey(*args, **kwargs)
 
         assert expected_result == key.format_for_rabbitmq()
@@ -44,7 +48,12 @@ class TestDepthConsumeKey:
         'exchange, market_tag, symbol_tag, expected_msg',
         fixture_format_for_rabbitmq_wrong()
     )
-    def test_format_for_rabbitmq_exceptions(exchange, market_tag, symbol_tag, expected_msg):
+    def test_format_for_rabbitmq_exceptions(
+        exchange: str,
+        market_tag: str,
+        symbol_tag: str,
+        expected_msg: str
+    ):
         with pytest.raises(ValueError, match=expected_msg):
             DepthConsumeKey(exchange, market_tag, symbol_tag).format_for_rabbitmq()
 
@@ -159,6 +168,7 @@ class TestPipeResponseRouter:
         router_task = asyncio.create_task(router.start())
 
         async def on_response1(data): consumer1_called.set()
+
         async def on_response2(data): consumer1_called.set()
 
         consumer_collection = router.prepare_consumers_of_response(pipe_request1)

--- a/tests/transport/real_test.py
+++ b/tests/transport/real_test.py
@@ -8,13 +8,13 @@ from ..utils import AsyncMock
 
 class TestRabbitConnection:
     def test_constructor_dont_init_connection_object(self):
-        conn = RabbitConnection('')
+        conn = RabbitConnection('test1.local')
 
         assert conn.connection is None
 
     @pytest.mark.asyncio
     async def test_constructor_trim_dsn(self):
-        dsn = ' \t test.local  '
+        dsn = ' \t test2.local  '
         expected_dsn = dsn.strip()
         assert dsn != expected_dsn
 
@@ -27,7 +27,7 @@ class TestRabbitConnection:
 
     @pytest.mark.asyncio
     async def test_create_channel_reuse_one_connection(self):
-        conn = RabbitConnection('test.local')
+        conn = RabbitConnection('test3.local')
 
         with patch('aio_pika.connect_robust', new_callable=AsyncMock):
             await conn.create_channel()
@@ -38,7 +38,7 @@ class TestRabbitConnection:
 
     @pytest.mark.asyncio
     async def test_create_channel_use_delivered_dsn(self):
-        dsn = 'test.local'
+        dsn = 'test4.local'
         conn = RabbitConnection(dsn)
         prefetch_count = 50
 

--- a/tests/transport/real_test.py
+++ b/tests/transport/real_test.py
@@ -6,8 +6,8 @@ from unittest.mock import ANY, Mock
 import aio_pika
 import pytest
 
-from galts_trade_api.transport.real import ConsumeDepthScrapingRequest, \
-    InitExchangeEntitiesRequest, RabbitConnection, RabbitConsumer, RealTransportFactory
+from galts_trade_api.transport.real import ConsumePriceDepthRequest, \
+    GetExchangeEntitiesRequest, RabbitConnection, RabbitConsumer, RealTransportFactory
 from ..utils import AsyncMock, cancel_other_tasks
 
 
@@ -159,12 +159,12 @@ def fixture_test_remote_methods_setup_callback():
         'exchange_info_dsn': exchange_info_dsn,
         'exchange_info_get_entities_timeout': exchange_info_get_entities_timeout,
     }
-    response1 = InitExchangeEntitiesRequest(
+    response1 = GetExchangeEntitiesRequest(
         exchange_info_dsn,
         exchange_info_get_entities_timeout
     )
 
-    yield constructor_args1, 'init_exchange_entities', {}, response1
+    yield constructor_args1, 'get_exchange_entities', {}, response1
 
     depth_scraping_queue_dsn = 'test.local'
     depth_scraping_queue_exchange = 'test-exchange'
@@ -175,13 +175,13 @@ def fixture_test_remote_methods_setup_callback():
     method_args2 = {
         'consume_keys': [],
     }
-    response2 = ConsumeDepthScrapingRequest(
+    response2 = ConsumePriceDepthRequest(
         depth_scraping_queue_dsn,
         depth_scraping_queue_exchange,
         frozenset()
     )
 
-    yield constructor_args2, 'get_depth_scraping_consumer', method_args2, response2
+    yield constructor_args2, 'consume_price_depth', method_args2, response2
 
 
 @pytest.mark.usefixtures('unexpected_exceptions_handler')

--- a/tests/transport/real_test.py
+++ b/tests/transport/real_test.py
@@ -292,7 +292,7 @@ class TestRealTransportFactory:
             is_called.set()
             await asyncio.sleep(1)
 
-        router_cls.return_value.start.return_value = start()
+        router_cls.return_value.start = start
 
         factory = self._get_factory_instance(process_ready_timeout=0.1)
         await factory.init()
@@ -338,7 +338,7 @@ class TestRealTransportFactory:
             start_is_called.set()
             raise expected_exception
 
-        router_cls.return_value.start.return_value = start()
+        router_cls.return_value.start = start
 
         factory = self._get_factory_instance(process_ready_timeout=0.1)
         await factory.init()

--- a/tests/transport/real_test.py
+++ b/tests/transport/real_test.py
@@ -230,9 +230,9 @@ class TestRealTransportFactory:
         process_cls.side_effect = self._factory_process_constructor_which_set_event(process_cls)
 
         factory = self._get_factory_instance()
+        await factory.init()
 
         with pytest.raises(RuntimeError, match='should be created only once'):
-            await factory.init()
             await factory.init()
 
         cancel_other_async_tasks()

--- a/tests/transport/real_test.py
+++ b/tests/transport/real_test.py
@@ -1,0 +1,49 @@
+from unittest.mock import patch
+
+import pytest
+
+from galts_trade_api.transport.real import RabbitConnection
+from ..utils import AsyncMock
+
+
+class TestRabbitConnection:
+    def test_constructor_dont_init_connection_object(self):
+        conn = RabbitConnection('')
+
+        assert conn.connection is None
+
+    @pytest.mark.asyncio
+    async def test_constructor_trim_dsn(self):
+        dsn = ' \t test.local  '
+        expected_dsn = dsn.strip()
+        assert dsn != expected_dsn
+
+        conn = RabbitConnection(dsn)
+
+        with patch('aio_pika.connect_robust', new_callable=AsyncMock) as connect_robust:
+            await conn.create_channel()
+
+        connect_robust.assert_called_once_with(expected_dsn)
+
+    @pytest.mark.asyncio
+    async def test_create_channel_reuse_one_connection(self):
+        conn = RabbitConnection('test.local')
+
+        with patch('aio_pika.connect_robust', new_callable=AsyncMock):
+            await conn.create_channel()
+            first_execution_connection = conn.connection
+            await conn.create_channel()
+
+        assert conn.connection is first_execution_connection
+
+    @pytest.mark.asyncio
+    async def test_create_channel_use_delivered_dsn(self):
+        dsn = 'test.local'
+        conn = RabbitConnection(dsn)
+        prefetch_count = 50
+
+        with patch('aio_pika.connect_robust', new_callable=AsyncMock) as connect_robust:
+            result = await conn.create_channel(prefetch_count=prefetch_count)
+
+        connect_robust.assert_called_once_with(dsn)
+        result.set_qos.assert_called_once_with(prefetch_count=prefetch_count)

--- a/tests/transport/real_test.py
+++ b/tests/transport/real_test.py
@@ -105,6 +105,33 @@ class TestRabbitConsumer:
         assert channel.declare_queue.return_value is consumer.queue
 
 
+def fixture_constructor_cast_properties():
+    # String properties
+    props = (
+        'exchange_info_dsn',
+        'depth_scraping_queue_dsn',
+        'depth_scraping_queue_exchange',
+    )
+
+    for prop in props:
+        yield prop, None, None
+        yield prop, 1, '1'
+        yield prop, 2.0, '2.0'
+        yield prop, False, 'False'
+        yield prop, ' test ', 'test'
+
+    # Float properties
+    props = (
+        'exchange_info_get_entities_timeout',
+        'process_ready_timeout',
+    )
+
+    for prop in props:
+        yield prop, '-1', -1
+        yield prop, '1', 1
+        yield prop, '2.0', 2.0
+
+
 def fixture_init_starts_transport_process():
     yield None
     yield True
@@ -112,9 +139,12 @@ def fixture_init_starts_transport_process():
 
 
 class TestRealTransportFactory:
-    @pytest.mark.skip
-    def test_constructor(self):
-        pass
+    @pytest.mark.parametrize('prop, arg_value, expected_value',
+        fixture_constructor_cast_properties())
+    def test_constructor_cast_properties(self, prop, arg_value, expected_value):
+        factory = RealTransportFactory(**{prop: arg_value})
+
+        assert getattr(factory, prop) == expected_value
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize('loop_debug', fixture_init_starts_transport_process())

--- a/tests/transport/real_test.py
+++ b/tests/transport/real_test.py
@@ -133,6 +133,8 @@ class TestRealTransportFactory:
         )
         process_class.instance.start.assert_called_once()
 
+        cancel_other_tasks()
+
     @pytest.mark.asyncio
     async def test_init_exception_for_second_call(self):
         factory = RealTransportFactory()
@@ -145,6 +147,8 @@ class TestRealTransportFactory:
                 )
                 await factory.init()
                 await factory.init()
+
+        cancel_other_tasks()
 
     @pytest.mark.asyncio
     async def test_init_exception_for_long_transport_process_init(self):

--- a/tests/transport/real_test.py
+++ b/tests/transport/real_test.py
@@ -256,6 +256,7 @@ class TestRealTransportFactory:
             'galts_trade_api.transport.real.PipeResponseRouter',
             autospec=True
         )
+        router_instance = router_cls.return_value
         create_task = mocker.patch('asyncio.create_task', autospec=True)
 
         factory = self._get_factory_instance(process_ready_timeout=0.1)
@@ -264,9 +265,9 @@ class TestRealTransportFactory:
         cancel_other_tasks()
 
         router_cls.assert_called_once()
-        router_cls.return_value.start.assert_called_once()
+        router_instance.start.assert_called_once()
 
-        create_task.assert_called_once_with(router_cls.return_value.start())
+        create_task.assert_called_once()
         create_task.return_value.add_done_callback.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/transport/real_test.py
+++ b/tests/transport/real_test.py
@@ -373,8 +373,7 @@ class TestRealTransportFactory:
         )
         process_cls.side_effect = self._factory_process_constructor_which_set_event(process_cls)
 
-        async def cb(data):
-            assert data == expected_response
+        async def cb(data): assert data == expected_response
 
         factory = self._get_factory_instance(**factory_args)
         await factory.init()

--- a/tests/transport/real_test.py
+++ b/tests/transport/real_test.py
@@ -7,14 +7,22 @@ from ..utils import AsyncMock
 
 
 class TestRabbitConnection:
+    def test_constructor_is_singleton(self):
+        conn_a = RabbitConnection('test1.local')
+        conn_b = RabbitConnection('test1.local')
+        conn_c = RabbitConnection('test2.local')
+
+        assert conn_a is conn_b
+        assert conn_a is not conn_c
+
     def test_constructor_dont_init_connection_object(self):
-        conn = RabbitConnection('test1.local')
+        conn = RabbitConnection('test3.local')
 
         assert conn.connection is None
 
     @pytest.mark.asyncio
     async def test_constructor_trim_dsn(self):
-        dsn = ' \t test2.local  '
+        dsn = ' \t test4.local  '
         expected_dsn = dsn.strip()
         assert dsn != expected_dsn
 
@@ -27,7 +35,7 @@ class TestRabbitConnection:
 
     @pytest.mark.asyncio
     async def test_create_channel_reuse_one_connection(self):
-        conn = RabbitConnection('test3.local')
+        conn = RabbitConnection('test5.local')
 
         with patch('aio_pika.connect_robust', new_callable=AsyncMock):
             await conn.create_channel()
@@ -38,7 +46,7 @@ class TestRabbitConnection:
 
     @pytest.mark.asyncio
     async def test_create_channel_use_delivered_dsn(self):
-        dsn = 'test4.local'
+        dsn = 'test6.local'
         conn = RabbitConnection(dsn)
         prefetch_count = 50
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import ast
+import asyncio
 import inspect
 import sys
 import time
@@ -95,3 +96,10 @@ def fixture_grpc_error_status_codes(*args) -> Generator:
 
     for status_code in error_status_codes:
         yield (status_code, *args)
+
+
+def cancel_other_tasks():
+    """For async loop clean-up purposes"""
+    for t in asyncio.all_tasks():
+        if t is not asyncio.current_task():
+            t.cancel()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -51,7 +51,7 @@ def thread_with_timeout(target: Callable, timeout: float = 1) -> Generator:
             target()
         except Exception as e:
             exception = e
-            raise
+            sys.exit(1)
         finally:
             is_finished_event.set()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,86 @@
+import ast
+import inspect
+import time
+from contextlib import contextmanager
+from threading import Event, Thread
+from time import perf_counter
+from typing import Any, Callable, Dict, Generator
+
+import grpc
+
+
+def wait_for_result(
+    function: Callable,
+    expected_result: Any = True,
+    strict: bool = True,
+    timeout: float = 1,
+    delay: float = 0.01
+) -> bool:
+    threshold_waiting_time = perf_counter() + timeout
+    while perf_counter() < threshold_waiting_time:
+        result = function()
+
+        if result is expected_result or (not strict and result == expected_result):
+            return True
+
+        time.sleep(delay)
+
+    return False
+
+
+@contextmanager
+def thread_with_timeout(target: Callable, timeout: float = 1) -> Generator:
+    is_finished = Event()
+    exception = None
+
+    def wrapper(is_finished_event: Event) -> None:
+        nonlocal exception
+        try:
+            target()
+        except Exception as e:
+            exception = e
+            raise
+        finally:
+            is_finished_event.set()
+
+    Thread(target=wrapper, args=(is_finished,), daemon=True).start()
+
+    yield
+
+    if not is_finished.wait(timeout):
+        raise RuntimeError(f'Timeout exceeded: {timeout} sec')
+
+    if exception:
+        raise exception
+
+
+def get_decorators(cls) -> Dict:
+    """Inspired by: https://stackoverflow.com/a/31197273"""
+    target = cls
+    decorators = {}
+
+    def visit_function_def(node) -> None:
+        decorators[node.name] = []
+        for n in node.decorator_list:
+            if isinstance(n, ast.Call):
+                name = n.func.attr if isinstance(n.func, ast.Attribute) else n.func.id
+            else:
+                name = n.attr if isinstance(n, ast.Attribute) else n.id
+
+            decorators[node.name].append(name)
+
+    node_iter = ast.NodeVisitor()
+    node_iter.visit_FunctionDef = visit_function_def
+    node_iter.visit(ast.parse(inspect.getsource(target)))
+
+    return decorators
+
+
+def fixture_grpc_error_status_codes(*args) -> Generator:
+    error_status_codes = [
+        grpc.StatusCode.UNKNOWN,
+        grpc.StatusCode.DEADLINE_EXCEEDED
+    ]
+
+    for status_code in error_status_codes:
+        yield (status_code, *args)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import ast
 import inspect
+import sys
 import time
 from contextlib import contextmanager
 from threading import Event, Thread
@@ -9,10 +10,10 @@ from unittest.mock import MagicMock
 
 import grpc
 
-try:
+if sys.version_info >= (3, 8):
     from unittest.mock import AsyncMock
-except ImportError:
-    # For simple testing of async code in Python 3.7
+else:
+    # For simple testing of async code in Python before 3.8
     # Got from https://stackoverflow.com/a/32498408/3155344
     class AsyncMock(MagicMock):
         async def __call__(self, *args, **kwargs):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,8 +5,18 @@ from contextlib import contextmanager
 from threading import Event, Thread
 from time import perf_counter
 from typing import Any, Callable, Dict, Generator
+from unittest.mock import MagicMock
 
 import grpc
+
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    # For simple testing of async code in Python 3.7
+    # Got from https://stackoverflow.com/a/32498408/3155344
+    class AsyncMock(MagicMock):
+        async def __call__(self, *args, **kwargs):
+            return super(AsyncMock, self).__call__(*args, **kwargs)
 
 
 def wait_for_result(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -98,7 +98,7 @@ def fixture_grpc_error_status_codes(*args) -> Generator:
         yield (status_code, *args)
 
 
-def cancel_other_tasks():
+def cancel_other_async_tasks() -> None:
     """For async loop clean-up purposes"""
     for t in asyncio.all_tasks():
         if t is not asyncio.current_task():

--- a/tox.ini
+++ b/tox.ini
@@ -14,10 +14,11 @@ deps =
     pytest-mock
     grpcio-testing
     cover: pytest-cov
+    teamcity-messages
 commands =
     python setup.py clean --all build_ext --force --inplace
-    nocover: {posargs:pytest -vv --ignore=src}
-    cover: {posargs:pytest -vv --cov --cov-report=term-missing}
+    nocover: {posargs:pytest --ignore=src}
+    cover: {posargs:pytest --cov --cov-report=term-missing}
 usedevelop =
     nocover: false
     cover: true

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ passenv = *
 deps =
     pytest
     pytest-asyncio
+    pytest-mock
     grpcio-testing
     cover: pytest-cov
 commands =


### PR DESCRIPTION
Покрыл весь код фреймворка тестами. Для простоты кода тестов добавил плагин `pytest-mock`, который позволяет использовать фикстуру `mocker` и мокать методы без контекстного менеджера.

Добавил в Docker Compose сервис для запуска `tox`, чтобы было удобнее прогонять тесты для разных окружений. И заменил его родительский образ с Alpine на Debian Buster, т.к. первое это ОС семейства MUSL, а они не соответствуют требованиям дистрибуции пакетов питона `manylinux1`. Из-за этого с PyPi скачивается версия `protobuf` без откомпилированных библиотек (и тесты падают). Заодно указал более свежие версии питона внутри `tox`.

Также переименовал несколько методов и что-то отрефакторил с целью улучшить семантику. Улучшил код проверки целостности данных в ответ на gRPC запрос `ExchangeInfo.GetEntities()`. Устранил проблему, когда один из колбеков, зарегистрированных на подписку на обновление цен мешал работе остальных, если в нём возникало исключение. Кое-где добавил код, останавливающий асинхронные подзадачи, если родительская задача была остановлена. А все прочие изменения в `src` (скорее всего) сделаны для упрощения тестирования.