### PR TITLE
Don't call default exception handler if a patch has been setup

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -31,10 +31,10 @@ async def start_trade_system(program_env: AsyncProgramEnv) -> None:
 
     await terminal.subscribe_to_prices(
         on_price,
-        [
+        {
             DepthConsumeKey(exchange_tag='binance', symbol_tag='BTCUSDT'),
             DepthConsumeKey(exchange_tag='binance', symbol_tag='BTCUSDC'),
-        ]
+        }
     )
 
     logger.info('Init finished!')

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='galts-trade-api',
-    version='0.1.0',
+    version='0.1.1',
     license='Mozilla Public License 2.0',
     author='Sergey Nevmerzhitsky',
     author_email='sergey.nevmerzhitsky@gmail.com',

--- a/src/galts_trade_api/asyncio_helper.py
+++ b/src/galts_trade_api/asyncio_helper.py
@@ -109,10 +109,11 @@ class AsyncProgramEnv:
         self._exception_handler_patch = value
 
     def exception_handler(self, loop: asyncio.AbstractEventLoop, context: Dict[str, Any]) -> None:
+        logger.info('Caught exception', process_id=os.getpid())
+
         if self.exception_handler_patch:
             self.exception_handler_patch(loop, context)
-
-        logger.info('Caught exception', process_id=os.getpid())
-        loop.default_exception_handler(context)
+        else:
+            loop.default_exception_handler(context)
 
         loop.create_task(shutdown(loop))

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -1,7 +1,7 @@
 import datetime
 from asyncio import Event, wait_for
 from decimal import Decimal
-from typing import Awaitable, Callable, Dict, List, Mapping, MutableMapping, Optional, Sequence, \
+from typing import Awaitable, Callable, Collection, Dict, List, Mapping, MutableMapping, Optional, \
     Tuple, Union
 
 from .asset import Asset, Symbol
@@ -83,7 +83,7 @@ class Terminal:
     async def subscribe_to_prices(
         self,
         callback: OnPriceCallable,
-        consume_keys: Optional[Sequence[DepthConsumeKey]] = None
+        consume_keys: Optional[Collection[DepthConsumeKey]] = None
     ) -> None:
         await self.transport_factory.consume_price_depth(
             lambda event: callback(*event),

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -1,7 +1,8 @@
 import datetime
 from asyncio import Event, wait_for
 from decimal import Decimal
-from typing import Awaitable, Callable, Dict, List, Mapping, MutableMapping, Optional, Tuple, Union
+from typing import Awaitable, Callable, Dict, List, Mapping, MutableMapping, Optional, Sequence, \
+    Tuple, Union
 
 from .asset import Asset, Symbol
 from .exchange import Exchange, Market
@@ -32,7 +33,7 @@ class Terminal:
         return self._transport_factory
 
     @transport_factory.setter
-    def transport_factory(self, value):
+    def transport_factory(self, value: TransportFactory):
         self._transport_factory = value
 
     @property
@@ -82,7 +83,7 @@ class Terminal:
     async def subscribe_to_prices(
         self,
         callback: OnPriceCallable,
-        consume_keys: Optional[List[DepthConsumeKey]] = None
+        consume_keys: Optional[Sequence[DepthConsumeKey]] = None
     ) -> None:
         await self.transport_factory.consume_price_depth(
             lambda event: callback(*event),

--- a/tests/asyncio_helper_test.py
+++ b/tests/asyncio_helper_test.py
@@ -198,3 +198,4 @@ class TestAsyncProgramEnv:
         env.exception_handler(loop, context)
 
         assert is_called.is_set()
+        loop.default_exception_handler.assert_not_called()


### PR DESCRIPTION
Без этого тяжело сделать полностью JSON-логи в ТС, т.к. дефолтный перехватчик всегда вызывает `logger.error()` с огромным многострочным текстом.