### PR TITLE
Resolve depths update callback slowness on high updates frequence

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+**Developer, don't forget to update version of the package in the file `setup.py`!**

--- a/examples/example.py
+++ b/examples/example.py
@@ -19,7 +19,7 @@ async def start_trade_system(program_env: AsyncProgramEnv) -> None:
     )
     logger.debug(f'transport={transport}')
 
-    terminal = Terminal(transport)
+    terminal = Terminal.factory(transport)
     logger.debug(f'terminal={terminal}')
     await terminal.init_transport()
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='galts-trade-api',
-    version='0.1.1',
+    version='0.2.0',
     license='Mozilla Public License 2.0',
     author='Sergey Nevmerzhitsky',
     author_email='sergey.nevmerzhitsky@gmail.com',

--- a/src/galts_trade_api/__init__.py
+++ b/src/galts_trade_api/__init__.py
@@ -1,0 +1,3 @@
+from .structlogger import get_logger
+
+logger = get_logger('galts_trade_api')

--- a/src/galts_trade_api/asset.py
+++ b/src/galts_trade_api/asset.py
@@ -1,5 +1,12 @@
 import datetime
+from enum import Enum, unique
 from typing import Optional
+
+
+@unique
+class DealSide(Enum):
+    BUY = 'buy'
+    SELL = 'sell'
 
 
 class Asset:

--- a/src/galts_trade_api/asyncio_helper.py
+++ b/src/galts_trade_api/asyncio_helper.py
@@ -4,9 +4,7 @@ import signal
 from functools import partial
 from typing import AbstractSet, Any, Awaitable, Callable, Dict, List, Optional
 
-from .structlogger import get_logger
-
-logger = get_logger('galts_trade_api')
+from . import logger
 
 LoopExceptionHandlerCallable = Callable[[asyncio.AbstractEventLoop, Dict[str, Any]], Any]
 

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -26,9 +26,9 @@ OnPriceCallable = Callable[[str, str, str, datetime.datetime, PriceDepth, PriceD
 class Terminal:
     @classmethod
     def factory(cls, transport: TransportFactory, depths_limit_per_market: int = 1) -> Terminal:
-        mdb = MarketsDepthsBuffer(depths_limit_per_market)
+        depths = MarketsDepthsBuffer(depths_limit_per_market)
 
-        return cls(transport, mdb)
+        return cls(transport, depths)
 
     def __init__(self, transport: TransportFactory, depths: MarketsDepthsBuffer):
         self._transport_factory: TransportFactory = transport

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -17,7 +17,7 @@ from .transport import DepthConsumeKey, TransportFactory
 PriceLevelWithoutFee = Tuple[Decimal, Decimal]
 PriceLevelWithFee = Tuple[Decimal, Decimal, Optional[Decimal]]
 PriceLevel = Union[PriceLevelWithoutFee, PriceLevelWithFee]
-PriceDepth = List[PriceLevel]
+PriceDepth = Tuple[PriceLevel]
 FullDepth = Tuple[PriceDepth, PriceDepth]
 
 OnPriceCallable = Callable[[str, str, str, datetime.datetime, PriceDepth, PriceDepth], Awaitable]
@@ -241,7 +241,6 @@ def depths_updater(terminal: Terminal, callback: Callable) -> OnPriceCallable:
     busyness_flag = Event()
     latest_update = []
 
-    # @TODO Make all args immutable
     async def on_depth_update(
         exchange_tag: str,
         market_tag: str,

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -202,8 +202,11 @@ class MarketsDepthsBuffer:
         if market_id not in self._depths:
             self._depths[market_id] = deque(maxlen=self.limit_per_market)
 
-        # @TODO Don't save the same
         record = (time, (bids, asks,),)
+
+        if len(self._depths[market_id]) > 0 and self._depths[market_id][0] == record:
+            return
+
         self._depths[market_id].appendleft(record)
 
     def get_depths_of_market(self, market_id: int) -> Deque[Tuple[datetime.datetime, FullDepth]]:

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -51,7 +51,7 @@ class Terminal:
         self._transport_factory = value
 
     @property
-    def depths(self) -> MarketsDepthsBuffer:
+    def depths(self):
         return self._depths
 
     @property

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -239,7 +239,7 @@ class MarketsDepthsBuffer:
         return all(are_known)
 
 
-def depths_updater(terminal: Terminal, callback: Callable) -> OnPriceCallable:
+def depths_updater(terminal: Terminal, callback: OnPriceCallable) -> OnPriceCallable:
     busyness_flag = Event()
     latest_update = []
 

--- a/src/galts_trade_api/terminal.py
+++ b/src/galts_trade_api/terminal.py
@@ -5,7 +5,7 @@ from asyncio import Event, wait_for
 from collections import deque
 from copy import copy
 from decimal import Decimal
-from typing import Awaitable, Callable, Collection, Deque, Dict, List, Mapping, MutableMapping, \
+from typing import Awaitable, Callable, Collection, Deque, Dict, Mapping, MutableMapping, \
     Optional, Tuple, Union
 
 from . import logger
@@ -26,13 +26,13 @@ OnPriceCallable = Callable[[str, str, str, datetime.datetime, PriceDepth, PriceD
 class Terminal:
     @classmethod
     def factory(cls, transport: TransportFactory, depths_limit_per_market: int = 1) -> Terminal:
-        mdb = MarketsDepthBuffer(depths_limit_per_market)
+        mdb = MarketsDepthsBuffer(depths_limit_per_market)
 
         return cls(transport, mdb)
 
-    def __init__(self, transport: TransportFactory, depths: MarketsDepthBuffer):
+    def __init__(self, transport: TransportFactory, depths: MarketsDepthsBuffer):
         self._transport_factory: TransportFactory = transport
-        self._depths: MarketsDepthBuffer = depths
+        self._depths: MarketsDepthsBuffer = depths
 
         self._exchange_entities_inited = Event()
         self._assets_by_id: Dict[int, Asset] = {}
@@ -51,7 +51,7 @@ class Terminal:
         self._transport_factory = value
 
     @property
-    def depths(self) -> MarketsDepthBuffer:
+    def depths(self) -> MarketsDepthsBuffer:
         return self._depths
 
     @property
@@ -179,9 +179,8 @@ class Terminal:
         self._exchange_entities_inited.set()
 
 
-# @TODO Refactoring to an abstract class and inherit it
 # Term from https://www.investopedia.com/terms/d/depth-of-market.asp
-class MarketsDepthBuffer:
+class MarketsDepthsBuffer:
     def __init__(self, limit_per_market: int = 1):
         self._limit_per_market = int(limit_per_market)
         self._depths: Dict[int, Deque[Tuple[datetime.datetime, FullDepth]]] = {}

--- a/src/galts_trade_api/transport/real.py
+++ b/src/galts_trade_api/transport/real.py
@@ -309,8 +309,10 @@ class RealTransportProcess(Process):
     ) -> None:
         body = json.loads(message.body)
 
-        for depth in body['depth'].values():
-            for price_level in depth:
+        for kind in body['depth'].keys():
+            new_depth = []
+
+            for price_level in body['depth'][kind]:
                 rate = Decimal(price_level[0])
                 amount = Decimal(price_level[1])
 
@@ -319,7 +321,9 @@ class RealTransportProcess(Process):
                 else:
                     fee = None
 
-                price_level[:] = [rate, amount, fee]
+                new_depth.append((rate, amount, fee,))
+
+            body['depth'][kind] = tuple(new_depth)
 
         args = [
             body['exchange'],

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -465,9 +465,8 @@ class TestTerminal:
         depths_updater_mock.assert_called_once_with(terminal, cb)
 
     @pytest.mark.asyncio
-    async def test_subscribe_to_prices(self):
-        # @TODO Cover new cases
-        pytest.skip('Not finished')
+    async def test_subscribe_to_prices_correctly_init_callback(self, mocker: MockFixture):
+        logger_mock = mocker.patch('galts_trade_api.terminal.logger')
 
         is_called = Event()
         data = ('exchange', 'market', 'symbol', datetime.utcnow(), (), (),)
@@ -482,6 +481,11 @@ class TestTerminal:
         keys = []
         await terminal.subscribe_to_prices(cb, keys)
         assert is_called.is_set()
+        logger_mock.exception.assert_called_once_with(
+            'cannot_find_market',
+            exchange_tag='exchange',
+            market_tag='market'
+        )
 
 
 def factory_terminal(

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -489,10 +489,7 @@ class TestMarketsDepthsBuffer:
         assert prices.limit_per_market == limit
 
     @pytest.mark.parametrize('limit_per_market', [0, -5])
-    def test_constructor_exception_on_wrong_count_argument(
-        self,
-        limit_per_market: Any
-    ):
+    def test_constructor_exception_on_wrong_count_argument(self, limit_per_market: Any):
         with pytest.raises(ValueError, match='limit_per_market should be'):
             MarketsDepthsBuffer(limit_per_market)
 

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -467,11 +467,6 @@ class FakeTransportFactory(TransportFactory):
         return result
 
 
-def fixture_constructor_exception_on_wrong_count_argument():
-    yield 0, 'limit_per_market should be'
-    yield -5, 'limit_per_market should be'
-
-
 def fixture_no_prices_after_init():
     expected_msg = 'Prices for market with id 1 are unknown'
 

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -236,6 +236,14 @@ def fixture_init_exchange_entities_ignore_deleted_entities():
 
 
 class TestTerminal:
+    def test_factory_setup_properties(self):
+        factory = Mock(spec_set=TransportFactory)
+
+        result = Terminal.factory(factory, 5)
+
+        assert result.transport_factory is factory
+        assert result.depths.limit_per_market == 5
+
     def test_properties(self):
         factory1 = Mock(spec_set=TransportFactory)
         factory2 = Mock(spec_set=TransportFactory)

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -488,16 +488,12 @@ class TestMarketsDepthsBuffer:
 
         assert prices.limit_per_market == limit
 
-    @pytest.mark.parametrize(
-        'limit_per_market, expected_msg',
-        fixture_constructor_exception_on_wrong_count_argument()
-    )
+    @pytest.mark.parametrize('limit_per_market', [0, -5])
     def test_constructor_exception_on_wrong_count_argument(
         self,
-        limit_per_market: Any,
-        expected_msg: str
+        limit_per_market: Any
     ):
-        with pytest.raises(ValueError, match=expected_msg):
+        with pytest.raises(ValueError, match='limit_per_market should be'):
             MarketsDepthsBuffer(limit_per_market)
 
     @pytest.mark.parametrize('expected_msg, method_name, args', fixture_no_prices_after_init())

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -467,6 +467,11 @@ class FakeTransportFactory(TransportFactory):
         return result
 
 
+def fixture_constructor_exception_on_wrong_count_argument():
+    yield 0, 'limit_per_market should be'
+    yield -5, 'limit_per_market should be'
+
+
 def fixture_no_prices_after_init():
     expected_msg = 'Prices for market with id 1 are unknown'
 
@@ -483,11 +488,17 @@ class TestMarketsDepthsBuffer:
 
         assert prices.limit_per_market == limit
 
-    def test_constructor_exception_on_wrong_count_argument(self):
-        with pytest.raises(ValueError, match='limit_per_market should be'):
-            MarketsDepthsBuffer(0)
-        with pytest.raises(ValueError, match='limit_per_market should be'):
-            MarketsDepthsBuffer(-5)
+    @pytest.mark.parametrize(
+        'limit_per_market, expected_msg',
+        fixture_constructor_exception_on_wrong_count_argument()
+    )
+    def test_constructor_exception_on_wrong_count_argument(
+        self,
+        limit_per_market: Any,
+        expected_msg: str
+    ):
+        with pytest.raises(ValueError, match=expected_msg):
+            MarketsDepthsBuffer(limit_per_market)
 
     @pytest.mark.parametrize('expected_msg, method_name, args', fixture_no_prices_after_init())
     def test_no_prices_after_init(self, expected_msg: str, method_name: str, args: Tuple[Any]):

--- a/tests/transport/real_test.py
+++ b/tests/transport/real_test.py
@@ -490,14 +490,14 @@ def fixture_consume_price_depth_parse_json():
         market_tag,
         symbol_tag,
         datetime.datetime(2000, 1, 1, 0, 1, 23),
-        [
-            [Decimal('1.2'), Decimal('3.4'), None],
-            [Decimal('5.6'), Decimal('7.8'), Decimal('9')],
-        ],
-        [
-            [Decimal('1.2'), Decimal('3.4'), Decimal('5')],
-            [Decimal('6.7'), Decimal('8.9'), None],
-        ],
+        (
+            (Decimal('1.2'), Decimal('3.4'), None,),
+            (Decimal('5.6'), Decimal('7.8'), Decimal('9'),),
+        ),
+        (
+            (Decimal('1.2'), Decimal('3.4'), Decimal('5'),),
+            (Decimal('6.7'), Decimal('8.9'), None,),
+        ),
     ]
 
 


### PR DESCRIPTION
Добавил механизм буферизации стаканов цен в объекте терминала, а также игнорирование колбека, установленного на событие обновления стаканов, если предыдущее обновление всё ещё обрабатывается данным колбеком.

Заодно изменил типы аргументов данного колбека - теперь все они иммутабельные (были списки, сделал кортежи).

Все изменения покрыты тестами. Также вручную проверил, как будет работать ТС арбитража на этой версии фреймворка: совместимость не нарушена, но накопление обновлений цен уменьшилось лишь на некоторую долю. Чтобы оно пропало совсем, нужно код самой ТС переделывать на более асинхронный (сейчас он весь по сути синхронный). Этим займусь после мержа этого ПР.

Также я добавил шаблон для новых ПР в этом репозитории, фишка гх: https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository. Этот текст будет вставляться в описание нового ПР при его создании. Позволяет описать правила работы с репозиторием, процесс разработки и т.п.